### PR TITLE
feat(charts-core): standardize shared v3 chart contracts

### DIFF
--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartData.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartData.kt
@@ -5,11 +5,16 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
 /**
- * A unified chart data model.
+ * Immutable, indexed data shared by aligned-series charts.
  *
- * @param categories The indexed-dimension labels shared by all series (x-axis values for
- * bar/line charts, slice labels for pie charts, axes for radar charts).
- * @param series The series to render. Pie charts use exactly one series.
+ * Values at the same index in each series share a category. Categories are labels,
+ * not numeric coordinates. Replace data to update a chart rather than mutating input lists.
+ * Chart-specific validation determines permitted series counts, lengths, and values.
+ * Pie charts use their own slice model instead of this table.
+ *
+ * @param categories The indexed-dimension labels, such as bar labels or radar axes.
+ * Empty means no explicit labels; otherwise the count must match each series' value count.
+ * @param series The ordered series to render. Series must have aligned value counts.
  */
 @Immutable
 data class ChartData(
@@ -17,7 +22,7 @@ data class ChartData(
     val series: ImmutableList<ChartSeries>,
 ) {
     /**
-     * Convenience constructor accepting mutable lists.
+     * Convenience constructor that defensively copies the supplied lists.
      *
      * @param categories The indexed-dimension labels shared by all series.
      * @param series The series to render.
@@ -34,15 +39,16 @@ data class ChartData(
 /**
  * A single named series of values within a [ChartData].
  *
- * @param name Optional series name. Required for charts that render a legend with
- * per-series entries.
+ * @param name Optional display name, not a unique series identifier.
  * @param values The series values. Mutating the supplied list after construction is
- * unsupported; the values are copied into an immutable list.
+ * safe but does not update this series; values are copied into an immutable list.
+ * Raw values retain Double precision; drawing coordinates can be normalized separately.
+ * Convert other numeric types or parse strings before constructing the series.
  */
 @Immutable
 data class ChartSeries(
     val name: String? = null,
-    val values: ImmutableList<Float>,
+    val values: ImmutableList<Double>,
 ) {
     /**
      * Convenience constructor accepting a mutable list of values.
@@ -52,7 +58,7 @@ data class ChartSeries(
      */
     constructor(
         name: String? = null,
-        values: List<Float>,
+        values: List<Double>,
     ) : this(
         name = name,
         values = values.toImmutableList(),
@@ -62,11 +68,11 @@ data class ChartSeries(
 /**
  * Converts a list of values into single-series [ChartData].
  *
- * @param categories The indexed-dimension labels. Defaults to the string form of each index.
+ * @param categories The indexed-dimension labels. Empty by default (no explicit labels).
  * @param seriesName Optional series name.
  */
-fun List<Float>.toChartData(
-    categories: List<String> = indices.map(Int::toString),
+fun List<Double>.toChartData(
+    categories: List<String> = emptyList(),
     seriesName: String? = null,
 ): ChartData =
     ChartData(

--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartSelection.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartSelection.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 
 /**
@@ -12,15 +13,18 @@ import androidx.compose.runtime.setValue
  * (e.g. a pie slice).
  *
  * Create with [rememberChartSelection] for interactive charts, or [staticChartSelection]
- * for deterministic preset selections used in screenshots and tests.
+ * for an initialized selection used in screenshots and tests. Neither factory disables
+ * interaction or animation. The index refers to source data, not an aggregated drawing index;
+ * charts are responsible for interpreting it and checking data bounds.
  *
- * @param onSelectionChanged Optional callback invoked whenever the selection changes.
+ * @param onSelectionChanged Optional callback invoked after a different index is selected or cleared.
  * @property selectedIndex The currently selected index, or `null` when nothing is selected.
  * @param initialIndex The initially selected index, or `null` for no initial selection.
  */
 @Stable
 class ChartSelection constructor(
     initialIndex: Int? = null,
+    onSelectionChanged: ((Int?) -> Unit)? = null,
 ) {
     /**
      * The currently selected index, or `null` when nothing is selected.
@@ -29,14 +33,16 @@ class ChartSelection constructor(
         private set
 
     /**
-     * Optional callback invoked whenever the selection changes.
+     * Optional callback invoked after the selection changes. Initialization, repeated
+     * selection of the same index, and clearing an already empty selection do not notify.
      */
-    var onSelectionChanged: ((Int?) -> Unit)? = null
+    var onSelectionChanged: ((Int?) -> Unit)? = onSelectionChanged
 
     /**
      * Selects the data point at [index].
      */
     fun select(index: Int) {
+        if (selectedIndex == index) return
         selectedIndex = index
         onSelectionChanged?.invoke(index)
     }
@@ -45,6 +51,7 @@ class ChartSelection constructor(
      * Clears the current selection.
      */
     fun clear() {
+        if (selectedIndex == null) return
         selectedIndex = null
         onSelectionChanged?.invoke(null)
     }
@@ -54,13 +61,25 @@ class ChartSelection constructor(
  * Creates a [ChartSelection] remembered for the current composition.
  *
  * @param initialIndex The initially selected index, or `null` for no initial selection.
+ * Changes to this argument during recomposition do not reset the selection.
+ * @param onSelectionChanged Receives actual selection changes using the latest callback
+ * from composition, without recreating the state holder. Assigning the holder's
+ * [ChartSelection.onSelectionChanged] property explicitly overrides this callback.
  */
 @Composable
-fun rememberChartSelection(initialIndex: Int? = null): ChartSelection =
-    remember { ChartSelection(initialIndex = initialIndex) }
+fun rememberChartSelection(
+    initialIndex: Int? = null,
+    onSelectionChanged: ((Int?) -> Unit)? = null,
+): ChartSelection {
+    val currentOnSelectionChanged by rememberUpdatedState(onSelectionChanged)
+    return remember {
+        ChartSelection(initialIndex = initialIndex) { index -> currentOnSelectionChanged?.invoke(index) }
+    }
+}
 
 /**
- * Creates a [ChartSelection] fixed to [index]. Used for deterministic rendering,
- * e.g. screenshots and documentation images.
+ * Creates a new, unremembered [ChartSelection] initialized to [index], e.g. for
+ * screenshots and documentation images. The returned state is still mutable;
+ * this factory does not lock selection or disable interaction or animation.
  */
 fun staticChartSelection(index: Int): ChartSelection = ChartSelection(initialIndex = index)

--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartValueFormatter.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/model/ChartValueFormatter.kt
@@ -1,26 +1,33 @@
 package io.github.dautovicharis.charts.model
 
 import kotlin.math.abs
-import kotlin.math.pow
-import kotlin.math.roundToInt
 
 /**
  * Formats a raw chart value for display.
  *
  * Used for axis labels, tooltips, and chart-specific value readouts.
- * Implementations must be deterministic across all platforms.
+ * Implementations should be deterministic for a given input.
  */
 fun interface ChartValueFormatter {
-    fun format(value: Float): String
+    fun format(value: Double): String
 }
 
 /**
  * Standard [ChartValueFormatter] factories.
+ *
+ * Finite values are rounded half away from zero using the decimal representation
+ * returned by `abs(value).toString()`, not the exact binary fraction. Scientific
+ * notation is expanded, and negative zero is suppressed. Nonfinite values are
+ * displayed as `NaN`, `Infinity`, and `-Infinity`.
+ *
+ * This assumes the platform's Double string uses decimal digits, an optional dot,
+ * and an optional `e`/`E` exponent. Last-digit differences between platform string
+ * representations can affect rounding at a boundary.
  */
 object ChartValueFormatters {
     /**
-     * Default format: values are rounded to two decimals, near-zero values are displayed
-     * as `0`, and the result matches the platform `toString` of the rounded double.
+     * Rounds to two decimal places, then trims trailing zeros while keeping `.0`
+     * for integers, including zero. For example: `3.0`, `41.7`, and `0.0`.
      */
     val Default: ChartValueFormatter = ChartValueFormatter(::formatDefaultValue)
 
@@ -35,23 +42,54 @@ object ChartValueFormatters {
     fun suffix(suffix: String): ChartValueFormatter = ChartValueFormatter { value -> "${Default.format(value)}$suffix" }
 
     /**
-     * Formats a value rounded to the given number of [precision] decimal places.
+     * Rounds and pads finite values to exactly [precision] decimal places, with no
+     * decimal point when [precision] is zero. Precision must be in `0..15`.
+     *
+     * @throws IllegalArgumentException if [precision] is outside `0..15`.
      */
     fun fixed(precision: Int): ChartValueFormatter {
-        require(precision >= 0) { "precision must be non-negative, was $precision" }
-        val factor = 10.0.pow(precision)
-        return ChartValueFormatter { value ->
-            val rounded = (value.toDouble() * factor).roundToInt() / factor
-            rounded.toString()
-        }
+        require(precision in 0..15) { "precision must be in 0..15, was $precision" }
+        return ChartValueFormatter { value -> formatFixedValue(value, precision) }
     }
 
-    // Avoid displaying "-0.0" for tiny values after rounding to two decimals.
-    private const val NEAR_ZERO_DISPLAY_EPSILON = 0.005
+    private fun formatDefaultValue(value: Double): String {
+        val trimmed = formatFixedValue(value, 2).trimEnd('0')
+        return if (trimmed.endsWith('.')) "${trimmed}0" else trimmed
+    }
 
-    private fun formatDefaultValue(value: Float): String {
-        val rounded = (value.toDouble() * 100.0).roundToInt() / 100.0
-        val normalized = if (abs(rounded) < NEAR_ZERO_DISPLAY_EPSILON) 0.0 else rounded
-        return normalized.toString()
+    private fun formatFixedValue(
+        value: Double,
+        precision: Int,
+    ): String {
+        if (value.isNaN()) return "NaN"
+        if (value == Double.POSITIVE_INFINITY) return "Infinity"
+        if (value == Double.NEGATIVE_INFINITY) return "-Infinity"
+
+        val source = abs(value).toString()
+        val exponentIndex = source.indexOf('e', ignoreCase = true)
+        val mantissa = if (exponentIndex < 0) source else source.substring(0, exponentIndex)
+        val exponent = if (exponentIndex < 0) 0 else source.substring(exponentIndex + 1).toInt()
+        val decimalPoint = mantissa.indexOf('.').let { if (it < 0) mantissa.length else it }
+        val digits = mantissa.replace(".", "")
+
+        // Keep only digits through the rounding place; even MAX_VALUE needs at most
+        // 309 integer + 15 fractional digits. Tiny exponents need no zero expansion.
+        val retainedLength = decimalPoint + exponent + precision
+        val rounded =
+            StringBuilder(
+                if (retainedLength <= 0) "0" else digits.take(retainedLength).padEnd(retainedLength, '0'),
+            )
+        if (retainedLength >= 0 && (digits.getOrNull(retainedLength) ?: '0') >= '5') {
+            var index = rounded.lastIndex
+            while (index >= 0 && rounded[index] == '9') {
+                rounded[index] = '0'
+                index--
+            }
+            if (index < 0) rounded.insert(0, '1') else rounded[index] = rounded[index] + 1
+        }
+
+        val padded = rounded.toString().padStart(precision + 1, '0')
+        val magnitude = if (precision == 0) padded else padded.dropLast(precision) + "." + padded.takeLast(precision)
+        return if (value < 0.0 && padded.any { it != '0' }) "-$magnitude" else magnitude
     }
 }

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChart.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChart.kt
@@ -105,7 +105,7 @@ private fun PieChartContent(
     var interactionSelection by remember(points, selection) { mutableStateOf<Int?>(null) }
     var interactionNonce by remember(points, selection) { mutableStateOf(0L) }
 
-    LaunchedEffect(interactionNonce) {
+    LaunchedEffect(points, selection, interactionNonce) {
         if (interactionSelection == null) return@LaunchedEffect
         delay(PIE_SELECTION_AUTO_DESELECT_TIMEOUT_MS)
         if (selection.selectedIndex == interactionSelection) {

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
@@ -126,6 +127,7 @@ internal fun PieChart(
         label = "donutHoleAnimation",
     )
 
+    val currentOnSliceTouched by rememberUpdatedState(onSliceTouched)
     val interactionModifier =
         if (interactionEnabled) {
             Modifier
@@ -138,7 +140,7 @@ internal fun PieChart(
                                 size = size,
                                 slices = interactionSlices,
                             )
-                        onSliceTouched(selectedIndex)
+                        currentOnSliceTouched(selectedIndex)
                     }
                 }
         } else {

--- a/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
+++ b/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
@@ -1,8 +1,11 @@
 package io.github.dautovicharis.charts.ui
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
@@ -17,6 +20,7 @@ import io.github.dautovicharis.charts.internal.format
 import io.github.dautovicharis.charts.internal.piechart.calculatePercentages
 import io.github.dautovicharis.charts.mock.MockTest.TITLE
 import io.github.dautovicharis.charts.mock.MockTest.colors
+import io.github.dautovicharis.charts.model.ChartSelection
 import io.github.dautovicharis.charts.model.PieSlice
 import io.github.dautovicharis.charts.model.staticChartSelection
 import io.github.dautovicharis.charts.style.PieChartDefaults
@@ -25,6 +29,8 @@ import kotlin.math.cos
 import kotlin.math.round
 import kotlin.math.sin
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class PieChartTest {
     private val pieSlices =
@@ -45,7 +51,7 @@ class PieChartTest {
                 PieChart(pieSlices, title = TITLE)
             }
 
-            onNodeWithTag(TestTags.PIE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.PIE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
         }
 
@@ -60,7 +66,7 @@ class PieChartTest {
                 PieChart(pieSlices, title = TITLE)
             }
 
-            onNodeWithTag(TestTags.PIE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.PIE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
             val size = onNodeWithTag(TestTags.PIE_CHART).fetchSemanticsNode().size
 
@@ -71,8 +77,8 @@ class PieChartTest {
                     down(sliceMiddlePosition)
                     up()
                 }
-                onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
-                onNodeWithText("${percentages[index]}%").isDisplayed()
+                onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).assertIsDisplayed()
+                onNodeWithText("${percentages[index]}%").assertIsDisplayed()
             }
         }
 
@@ -88,8 +94,8 @@ class PieChartTest {
             }
 
             onNodeWithTag(TestTags.PIE_CHART).assertDoesNotExist()
-            onNodeWithTag(TestTags.CHART_ERROR).isDisplayed()
-            onNodeWithText("${expectedError}\n").isDisplayed()
+            onNodeWithTag(TestTags.CHART_ERROR).assertIsDisplayed()
+            onNodeWithText("${expectedError}\n").assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -105,7 +111,7 @@ class PieChartTest {
                 PieChart(data = slices)
             }
 
-            onNodeWithTag(TestTags.PIE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.PIE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_ERROR).assertDoesNotExist()
         }
 
@@ -124,7 +130,7 @@ class PieChartTest {
                 )
             }
 
-            onNodeWithTag(TestTags.PIE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.PIE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
             val size = onNodeWithTag(TestTags.PIE_CHART).fetchSemanticsNode().size
 
@@ -135,8 +141,8 @@ class PieChartTest {
                     down(sliceMiddlePosition)
                     up()
                 }
-                onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
-                onNodeWithText("${percentages[index]}%").isDisplayed()
+                onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).assertIsDisplayed()
+                onNodeWithText("${percentages[index]}%").assertIsDisplayed()
             }
         }
 
@@ -157,9 +163,9 @@ class PieChartTest {
                 )
             }
 
-            onNodeWithTag(TestTags.PIE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.PIE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(expectedTitle)
-            onNodeWithText(expectedPercentage).isDisplayed()
+            onNodeWithText(expectedPercentage).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -188,6 +194,120 @@ class PieChartTest {
                 }.isSuccess
             }
             onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun pieChart_externalSelectionAndClear_updateDetails() =
+        runComposeUiTest {
+            val selection = ChartSelection()
+            setContent {
+                PieChart(pieSlices, title = TITLE, style = PieChartDefaults.style(selection = selection))
+            }
+
+            runOnIdle { selection.select(1) }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(labels[1])
+            onNodeWithText("20.0%").assertIsDisplayed()
+
+            runOnIdle { selection.clear() }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
+            onNodeWithText("20.0%").assertDoesNotExist()
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun pieChart_repeatedTap_renewsTimeoutWithoutDuplicateNotification() =
+        runComposeUiTest {
+            val notifications = mutableListOf<Int?>()
+            val selection = ChartSelection { notifications.add(it) }
+            setContent {
+                PieChart(pieSlices, title = TITLE, style = PieChartDefaults.style(selection = selection))
+            }
+
+            waitForIdle()
+            mainClock.autoAdvance = false
+
+            fun tapFirstSlice() {
+                val node = onNodeWithTag(TestTags.PIE_CHART)
+                val position = getCoordinatesForSlice(0, node.fetchSemanticsNode().size, createPieSlices(points))
+                node.performTouchInput {
+                    down(position)
+                    up()
+                }
+                repeat(2) { mainClock.advanceTimeByFrame() }
+                waitForIdle()
+            }
+
+            fun assertSelectedOnce() {
+                runOnIdle {
+                    assertEquals(expected = 0, actual = selection.selectedIndex)
+                    assertEquals(expected = listOf<Int?>(0), actual = notifications)
+                }
+                onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(labels[0])
+            }
+
+            tapFirstSlice()
+            mainClock.advanceTimeBy(2_000L, ignoreFrameDuration = true)
+            assertSelectedOnce()
+            tapFirstSlice()
+
+            // Past the first tap's deadline, but before the renewed deadline.
+            mainClock.advanceTimeBy(1_500L, ignoreFrameDuration = true)
+            assertSelectedOnce()
+            mainClock.advanceTimeBy(1_000L, ignoreFrameDuration = true)
+            assertSelectedOnce()
+
+            mainClock.advanceTimeBy(600L, ignoreFrameDuration = true)
+            repeat(2) { mainClock.advanceTimeByFrame() }
+            waitForIdle()
+            runOnIdle {
+                assertNull(selection.selectedIndex)
+                assertEquals(expected = listOf(0, null), actual = notifications)
+            }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun pieChart_replacedSelectionHolder_receivesGesturesAndOwnsTimeout() =
+        runComposeUiTest {
+            val oldSelection = ChartSelection()
+            val newSelection = ChartSelection()
+            var selection by mutableStateOf(oldSelection)
+            setContent {
+                PieChart(pieSlices, title = TITLE, style = PieChartDefaults.style(selection = selection))
+            }
+
+            var size = onNodeWithTag(TestTags.PIE_CHART).fetchSemanticsNode().size
+            val firstPosition = getCoordinatesForSlice(0, size, createPieSlices(points))
+            onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
+                down(firstPosition)
+                up()
+            }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(labels[0])
+
+            runOnIdle { selection = newSelection }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
+            size = onNodeWithTag(TestTags.PIE_CHART).fetchSemanticsNode().size
+            val secondPosition = getCoordinatesForSlice(1, size, createPieSlices(points))
+            onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
+                down(secondPosition)
+                up()
+            }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(labels[1])
+            runOnIdle {
+                assertEquals(expected = 0, actual = oldSelection.selectedIndex)
+                assertEquals(expected = 1, actual = newSelection.selectedIndex)
+            }
+
+            waitUntil(timeoutMillis = PIE_SELECTION_AUTO_DESELECT_TIMEOUT_MS + 2_000L) {
+                newSelection.selectedIndex == null
+            }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(TITLE)
+            runOnIdle {
+                assertEquals(expected = 0, actual = oldSelection.selectedIndex)
+                assertNull(newSelection.selectedIndex)
+            }
         }
 
     private data class SliceGeometry(

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataModelTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataModelTest.kt
@@ -1,5 +1,6 @@
 package io.github.dautovicharis.charts.unit.model
 
+import io.github.dautovicharis.charts.model.ChartData
 import io.github.dautovicharis.charts.model.ChartSeries
 import io.github.dautovicharis.charts.model.chartDataOf
 import io.github.dautovicharis.charts.model.toChartData
@@ -11,22 +12,22 @@ import kotlin.test.assertSame
 
 class ChartDataModelTest {
     @Test
-    fun floatList_toChartData_singleSeriesWithIndexCategories() {
+    fun doubleList_toChartData_singleSeriesWithoutCategories() {
         // Act
-        val data = listOf(1.0f, 2.0f, 3.0f).toChartData()
+        val data = listOf(1.0, 2.0, 3.0).toChartData()
 
         // Assert
-        assertContentEquals(actual = data.categories, expected = listOf("0", "1", "2"))
+        assertContentEquals(actual = data.categories, expected = emptyList())
         assertEquals(actual = data.series.size, expected = 1)
         assertNull(actual = data.series[0].name)
-        assertContentEquals(actual = data.series[0].values, expected = listOf(1.0f, 2.0f, 3.0f))
+        assertContentEquals(actual = data.series[0].values, expected = listOf(1.0, 2.0, 3.0))
     }
 
     @Test
-    fun floatList_toChartData_customCategoriesAndSeriesName() {
+    fun doubleList_toChartData_customCategoriesAndSeriesName() {
         // Act
         val data =
-            listOf(24.0f, 18.0f).toChartData(
+            listOf(24.0, 18.0).toChartData(
                 categories = listOf("Product A", "Product B"),
                 seriesName = "Sales",
             )
@@ -34,7 +35,17 @@ class ChartDataModelTest {
         // Assert
         assertContentEquals(actual = data.categories, expected = listOf("Product A", "Product B"))
         assertEquals(actual = data.series[0].name, expected = "Sales")
-        assertContentEquals(actual = data.series[0].values, expected = listOf(24.0f, 18.0f))
+        assertContentEquals(actual = data.series[0].values, expected = listOf(24.0, 18.0))
+    }
+
+    @Test
+    fun doubleList_toChartData_preservesPrecision() {
+        val values = listOf(16_777_217.0, 1.23456789012345, Double.MAX_VALUE)
+
+        val data = values.toChartData()
+
+        assertContentEquals(expected = values, actual = data.series.single().values)
+        assertContentEquals(expected = emptyList(), actual = data.categories)
     }
 
     @Test
@@ -43,34 +54,71 @@ class ChartDataModelTest {
         val data =
             chartDataOf(
                 categories = listOf("Jan", "Feb", "Mar"),
-                ChartSeries(name = "A", values = listOf(1.0f, 2.0f, 3.0f)),
-                ChartSeries(name = "B", values = listOf(4.0f, 5.0f, 6.0f)),
+                ChartSeries(name = "A", values = listOf(1.0, 2.0, 3.0)),
+                ChartSeries(name = "B", values = listOf(4.0, 5.0, 6.0)),
             )
 
         // Assert
         assertContentEquals(actual = data.categories, expected = listOf("Jan", "Feb", "Mar"))
         assertEquals(actual = data.series.size, expected = 2)
         assertEquals(actual = data.series[1].name, expected = "B")
-        assertContentEquals(actual = data.series[1].values, expected = listOf(4.0f, 5.0f, 6.0f))
+        assertContentEquals(actual = data.series[1].values, expected = listOf(4.0, 5.0, 6.0))
     }
 
     @Test
     fun chartSeries_mutableList_isCopied() {
         // Arrange
-        val mutable = mutableListOf(1.0f, 2.0f)
+        val mutable = mutableListOf(1.0, 2.0)
         val series = ChartSeries(values = mutable)
 
         // Act
-        mutable.add(3.0f)
+        mutable.add(3.0)
 
         // Assert
-        assertContentEquals(actual = series.values, expected = listOf(1.0f, 2.0f))
+        assertContentEquals(actual = series.values, expected = listOf(1.0, 2.0))
+    }
+
+    @Test
+    fun chartData_mutableCategoriesAndSeries_areCopied() {
+        val categories = mutableListOf("a", "b")
+        val series = mutableListOf(ChartSeries(values = listOf(1.0, 2.0)))
+        val data = ChartData(categories = categories, series = series)
+
+        categories[0] = "changed"
+        series.clear()
+
+        assertContentEquals(expected = listOf("a", "b"), actual = data.categories)
+        assertContentEquals(expected = listOf(1.0, 2.0), actual = data.series.single().values)
+    }
+
+    @Test
+    fun toChartData_mutableInputs_areCopied() {
+        val values = mutableListOf(1.0, 2.0)
+        val categories = mutableListOf("a", "b")
+        val data = values.toChartData(categories = categories)
+
+        values[0] = 100.0
+        categories.clear()
+
+        assertContentEquals(expected = listOf(1.0, 2.0), actual = data.series.single().values)
+        assertContentEquals(expected = listOf("a", "b"), actual = data.categories)
+    }
+
+    @Test
+    fun emptyData_doesNotInventCategoriesOrValues() {
+        val data = ChartData()
+        val singleSeries = emptyList<Double>().toChartData()
+
+        assertContentEquals(expected = emptyList(), actual = data.categories)
+        assertContentEquals(expected = emptyList(), actual = data.series)
+        assertContentEquals(expected = emptyList(), actual = singleSeries.categories)
+        assertContentEquals(expected = emptyList(), actual = singleSeries.series.single().values)
     }
 
     @Test
     fun chartData_copy_acceptsImmutableCollections() {
         // Arrange
-        val data = listOf(1.0f, 2.0f).toChartData(categories = listOf("a", "b"))
+        val data = listOf(1.0, 2.0).toChartData(categories = listOf("a", "b"))
 
         // Act
         val copy =
@@ -80,7 +128,7 @@ class ChartDataModelTest {
 
         // Assert
         assertContentEquals(actual = copy.categories, expected = listOf("x", "y"))
-        assertContentEquals(actual = copy.series[0].values, expected = listOf(1.0f, 2.0f))
+        assertContentEquals(actual = copy.series[0].values, expected = listOf(1.0, 2.0))
         assertSame(actual = data.series, expected = copy.series)
     }
 }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartSelectionTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartSelectionTest.kt
@@ -1,9 +1,18 @@
 package io.github.dautovicharis.charts.unit.model
 
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.model.ChartSelection
+import io.github.dautovicharis.charts.model.rememberChartSelection
+import io.github.dautovicharis.charts.model.staticChartSelection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 class ChartSelectionTest {
     @Test
@@ -51,7 +60,7 @@ class ChartSelectionTest {
         selection.select(1)
 
         // Assert
-        assertEquals(expected = listOf<Int?>(1, 1), actual = notified)
+        assertEquals(expected = listOf<Int?>(1), actual = notified)
     }
 
     @Test
@@ -68,4 +77,98 @@ class ChartSelectionTest {
         assertNull(actual = selection.selectedIndex)
         assertEquals(expected = listOf<Int?>(null), actual = notified)
     }
+
+    @Test
+    fun initializationAndRepeatedClear_doNotNotify() {
+        val notified = mutableListOf<Int?>()
+        val selection = ChartSelection { notified.add(it) }
+
+        selection.clear()
+        assertEquals(expected = emptyList(), actual = notified)
+
+        selection.select(1)
+        selection.clear()
+        selection.clear()
+        assertEquals(expected = listOf(1, null), actual = notified)
+    }
+
+    @Test
+    fun callback_observesUpdatedState() {
+        val selection = ChartSelection(initialIndex = 1)
+        val observed = mutableListOf<Int?>()
+        selection.onSelectionChanged = { index ->
+            assertEquals(expected = index, actual = selection.selectedIndex)
+            observed.add(index)
+        }
+
+        selection.select(2)
+        selection.clear()
+
+        assertEquals(expected = listOf(2, null), actual = observed)
+    }
+
+    @Test
+    fun callbackReplacementAndRemoval_applyWithoutNotification() {
+        val oldNotifications = mutableListOf<Int?>()
+        val newNotifications = mutableListOf<Int?>()
+        val selection = ChartSelection(initialIndex = 1) { oldNotifications.add(it) }
+        assertEquals(expected = emptyList(), actual = oldNotifications)
+
+        selection.onSelectionChanged = { newNotifications.add(it) }
+        selection.select(2)
+        selection.onSelectionChanged = null
+        selection.clear()
+
+        assertEquals(expected = emptyList(), actual = oldNotifications)
+        assertEquals(expected = listOf<Int?>(2), actual = newNotifications)
+        assertNull(selection.selectedIndex)
+    }
+
+    @Test
+    fun staticSelection_isInitializedButStillMutable() {
+        val selection = staticChartSelection(2)
+        assertEquals(expected = 2, actual = selection.selectedIndex)
+
+        selection.select(3)
+        assertEquals(expected = 3, actual = selection.selectedIndex)
+
+        selection.clear()
+        assertNull(selection.selectedIndex)
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun rememberedSelection_keepsIdentityAndUsesLatestCallback() =
+        runComposeUiTest {
+            val oldNotifications = mutableListOf<Int?>()
+            val newNotifications = mutableListOf<Int?>()
+            var initialIndex by mutableStateOf<Int?>(null)
+            var callback by mutableStateOf<((Int?) -> Unit)?>({ oldNotifications.add(it) })
+            lateinit var selection: ChartSelection
+            lateinit var originalSelection: ChartSelection
+
+            setContent {
+                val remembered = rememberChartSelection(initialIndex, callback)
+                SideEffect { selection = remembered }
+            }
+
+            runOnIdle {
+                originalSelection = selection
+                selection.select(1)
+                initialIndex = 10
+                callback = { newNotifications.add(it) }
+            }
+            runOnIdle {
+                assertSame(originalSelection, selection)
+                assertEquals(expected = 1, actual = selection.selectedIndex)
+                selection.select(2)
+                callback = null
+            }
+            runOnIdle {
+                assertSame(originalSelection, selection)
+                selection.clear()
+                assertEquals(expected = listOf<Int?>(1), actual = oldNotifications)
+                assertEquals(expected = listOf<Int?>(2), actual = newNotifications)
+            }
+        }
 }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartValueFormatterTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartValueFormatterTest.kt
@@ -1,5 +1,6 @@
 package io.github.dautovicharis.charts.unit.model
 
+import io.github.dautovicharis.charts.model.ChartValueFormatter
 import io.github.dautovicharis.charts.model.ChartValueFormatters
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,9 +13,14 @@ class ChartValueFormatterTest {
         val formatter = ChartValueFormatters.Default
 
         // Assert
-        assertEquals(expected = "41.7", actual = formatter.format(41.7f))
-        assertEquals(expected = "1.5", actual = formatter.format(1.5f))
-        assertEquals(expected = "3.0", actual = formatter.format(2.999f))
+        assertEquals(expected = "41.7", actual = formatter.format(41.7))
+        assertEquals(expected = "-41.7", actual = formatter.format(-41.7))
+        assertEquals(expected = "1.5", actual = formatter.format(1.5))
+        assertEquals(expected = "3.0", actual = formatter.format(3.0))
+        assertEquals(expected = "3.0", actual = formatter.format(2.999))
+        assertEquals(expected = "1.23", actual = formatter.format(1.234))
+        assertEquals(expected = "-1.24", actual = formatter.format(-1.236))
+        assertEquals(expected = "10.0", actual = formatter.format(9.999))
     }
 
     @Test
@@ -23,9 +29,27 @@ class ChartValueFormatterTest {
         val formatter = ChartValueFormatters.Default
 
         // Assert
-        assertEquals(expected = "0.0", actual = formatter.format(0.004f))
-        assertEquals(expected = "0.0", actual = formatter.format(-0.004f))
-        assertEquals(expected = "0.01", actual = formatter.format(0.01f))
+        for (value in listOf(0.0, -0.0, 0.004, -0.004, Double.MIN_VALUE, -Double.MIN_VALUE)) {
+            assertEquals(expected = "0.0", actual = formatter.format(value), message = "value=$value")
+        }
+        assertEquals(expected = "0.01", actual = formatter.format(0.01))
+        assertEquals(expected = "0.01", actual = formatter.format(0.005))
+        assertEquals(expected = "-0.01", actual = formatter.format(-0.005))
+    }
+
+    @Test
+    fun default_roundsDecimalTiesAwayFromZero() {
+        assertEquals(expected = "0.13", actual = ChartValueFormatters.Default.format(0.125))
+        assertEquals(expected = "-0.13", actual = ChartValueFormatters.Default.format(-0.125))
+        assertEquals(expected = "1.01", actual = ChartValueFormatters.Default.format(1.005))
+        assertEquals(expected = "-1.01", actual = ChartValueFormatters.Default.format(-1.005))
+    }
+
+    @Test
+    fun default_doesNotSaturateLargeValues() {
+        assertEquals(expected = "21474836.48", actual = ChartValueFormatters.Default.format(21_474_836.48))
+        assertEquals(expected = "-21474836.48", actual = ChartValueFormatters.Default.format(-21_474_836.48))
+        assertEquals(expected = "100000000000000000000.0", actual = ChartValueFormatters.Default.format(1.0e20))
     }
 
     @Test
@@ -34,7 +58,8 @@ class ChartValueFormatterTest {
         val formatter = ChartValueFormatters.prefix("$")
 
         // Assert
-        assertEquals(expected = "$41.7", actual = formatter.format(41.7f))
+        assertEquals(expected = "$41.7", actual = formatter.format(41.7))
+        assertEquals(expected = "$-41.7", actual = formatter.format(-41.7))
     }
 
     @Test
@@ -43,23 +68,160 @@ class ChartValueFormatterTest {
         val formatter = ChartValueFormatters.suffix("%")
 
         // Assert
-        assertEquals(expected = "41.7%", actual = formatter.format(41.7f))
+        assertEquals(expected = "41.7%", actual = formatter.format(41.7))
+        assertEquals(expected = "-41.7%", actual = formatter.format(-41.7))
     }
 
     @Test
     fun fixed_roundsToGivenPrecision() {
         // Assert
-        assertEquals(expected = "4.0", actual = ChartValueFormatters.fixed(0).format(3.7f))
-        assertEquals(expected = "3.7", actual = ChartValueFormatters.fixed(1).format(3.7f))
-        assertEquals(expected = "1.235", actual = ChartValueFormatters.fixed(3).format(1.23456f))
-        assertEquals(expected = "2.0", actual = ChartValueFormatters.fixed(0).format(1.5f))
+        assertEquals(expected = "4", actual = ChartValueFormatters.fixed(0).format(3.7))
+        assertEquals(expected = "-4", actual = ChartValueFormatters.fixed(0).format(-3.7))
+        assertEquals(expected = "3.7", actual = ChartValueFormatters.fixed(1).format(3.7))
+        assertEquals(expected = "1.235", actual = ChartValueFormatters.fixed(3).format(1.23456))
+        assertEquals(expected = "-1.235", actual = ChartValueFormatters.fixed(3).format(-1.23456))
     }
 
     @Test
-    fun fixed_negativePrecision_throws() {
-        // Assert
-        assertFailsWith<IllegalArgumentException> {
-            ChartValueFormatters.fixed(-1)
+    fun fixed_padsExactlyToPrecision() {
+        assertEquals(expected = "3", actual = ChartValueFormatters.fixed(0).format(3.0))
+        assertEquals(expected = "3.0", actual = ChartValueFormatters.fixed(1).format(3.0))
+        assertEquals(expected = "3.00", actual = ChartValueFormatters.fixed(2).format(3.0))
+        assertEquals(expected = "1.50", actual = ChartValueFormatters.fixed(2).format(1.5))
+        assertEquals(expected = "-1.50", actual = ChartValueFormatters.fixed(2).format(-1.5))
+        assertEquals(expected = "1.000000000000000", actual = ChartValueFormatters.fixed(15).format(1.0))
+    }
+
+    @Test
+    fun fixed_roundsDecimalTiesAwayFromZero() {
+        assertEquals(expected = "2", actual = ChartValueFormatters.fixed(0).format(1.5))
+        assertEquals(expected = "-2", actual = ChartValueFormatters.fixed(0).format(-1.5))
+        assertEquals(expected = "0.13", actual = ChartValueFormatters.fixed(2).format(0.125))
+        assertEquals(expected = "-0.13", actual = ChartValueFormatters.fixed(2).format(-0.125))
+        assertEquals(expected = "2.68", actual = ChartValueFormatters.fixed(2).format(2.675))
+        assertEquals(expected = "-2.68", actual = ChartValueFormatters.fixed(2).format(-2.675))
+    }
+
+    @Test
+    fun fixed_respectsValuesAdjacentToATie() {
+        val formatter = ChartValueFormatters.fixed(2)
+        assertEquals(expected = "0.12", actual = formatter.format(0.12499999999999999))
+        assertEquals(expected = "-0.12", actual = formatter.format(-0.12499999999999999))
+        assertEquals(expected = "0.13", actual = formatter.format(0.12500000000000003))
+        assertEquals(expected = "-0.13", actual = formatter.format(-0.12500000000000003))
+    }
+
+    @Test
+    fun fixed_carriesAcrossDecimalAndIntegerDigits() {
+        assertEquals(expected = "10.00", actual = ChartValueFormatters.fixed(2).format(9.999))
+        assertEquals(expected = "-10.00", actual = ChartValueFormatters.fixed(2).format(-9.999))
+        assertEquals(expected = "1.00", actual = ChartValueFormatters.fixed(2).format(0.999))
+        assertEquals(expected = "100", actual = ChartValueFormatters.fixed(0).format(99.5))
+        assertEquals(expected = "-100", actual = ChartValueFormatters.fixed(0).format(-99.5))
+    }
+
+    @Test
+    fun fixed_suppressesNegativeZeroAtEveryPrecision() {
+        for (precision in 0..15) {
+            val formatter = ChartValueFormatters.fixed(precision)
+            val expected = if (precision == 0) "0" else "0." + "0".repeat(precision)
+            for (value in listOf(0.0, -0.0, 1.0e-20, -1.0e-20, Double.MIN_VALUE, -Double.MIN_VALUE)) {
+                assertEquals(
+                    expected = expected,
+                    actual = formatter.format(value),
+                    message = "precision=$precision, value=$value",
+                )
+            }
         }
+        assertEquals(expected = "0", actual = ChartValueFormatters.fixed(0).format(-0.49))
+        assertEquals(expected = "0.00", actual = ChartValueFormatters.fixed(2).format(-0.004))
+    }
+
+    @Test
+    fun fixed_expandsScientificNotation() {
+        assertEquals(expected = "125000000000000000000.00", actual = ChartValueFormatters.fixed(2).format(1.25e20))
+        assertEquals(expected = "-125000000000000000000", actual = ChartValueFormatters.fixed(0).format(-1.25e20))
+        assertEquals(expected = "0.0000001250", actual = ChartValueFormatters.fixed(10).format(1.25e-7))
+        assertEquals(expected = "-0.0000001250", actual = ChartValueFormatters.fixed(10).format(-1.25e-7))
+        assertEquals(expected = "0.000000", actual = ChartValueFormatters.fixed(6).format(1.25e-7))
+    }
+
+    @Test
+    fun fixed_roundsTinyValuesAtMaximumPrecision() {
+        val formatter = ChartValueFormatters.fixed(15)
+        assertEquals(expected = "0.000000000000005", actual = formatter.format(5.0e-15))
+        assertEquals(expected = "0.000000000000001", actual = formatter.format(5.0e-16))
+        assertEquals(expected = "-0.000000000000001", actual = formatter.format(-5.0e-16))
+        assertEquals(expected = "0.000000000000000", actual = formatter.format(4.0e-16))
+        assertEquals(expected = "0.000000000000000", actual = formatter.format(-4.0e-16))
+    }
+
+    @Test
+    fun formatters_preserveDoublePrecision() {
+        assertEquals(expected = "16777217.13", actual = ChartValueFormatters.Default.format(16_777_217.125))
+        assertEquals(expected = "16777217.125", actual = ChartValueFormatters.fixed(3).format(16_777_217.125))
+        assertEquals(
+            expected = "9007199254740991",
+            actual = ChartValueFormatters.fixed(0).format(9_007_199_254_740_991.0),
+        )
+        assertEquals(expected = "1.234567890123456", actual = ChartValueFormatters.fixed(15).format(1.234567890123456))
+        assertEquals(
+            expected = "0.100000001490116",
+            actual = ChartValueFormatters.fixed(15).format(0.10000000149011612),
+        )
+    }
+
+    @Test
+    fun formatters_expandMaximumDoubleWithoutOverflow() {
+        // The decimal source is 1.7976931348623157E308, not the exact binary integer.
+        val integer = "17976931348623157" + "0".repeat(292)
+        assertEquals(expected = "$integer.0", actual = ChartValueFormatters.Default.format(Double.MAX_VALUE))
+        assertEquals(expected = "-$integer.0", actual = ChartValueFormatters.Default.format(-Double.MAX_VALUE))
+        for (precision in listOf(0, 2, 15)) {
+            val expected = if (precision == 0) integer else "$integer." + "0".repeat(precision)
+            val formatter = ChartValueFormatters.fixed(precision)
+            assertEquals(
+                expected = expected,
+                actual = formatter.format(Double.MAX_VALUE),
+                message = "precision=$precision",
+            )
+            assertEquals(
+                expected = "-$expected",
+                actual = formatter.format(-Double.MAX_VALUE),
+                message = "precision=$precision",
+            )
+        }
+    }
+
+    @Test
+    fun formatters_useExplicitNonfiniteStrings() {
+        val formatters =
+            listOf(
+                ChartValueFormatters.Default,
+                ChartValueFormatters.fixed(0),
+                ChartValueFormatters.fixed(2),
+                ChartValueFormatters.fixed(15),
+            )
+        for (formatter in formatters) {
+            assertEquals(expected = "NaN", actual = formatter.format(Double.NaN))
+            assertEquals(expected = "Infinity", actual = formatter.format(Double.POSITIVE_INFINITY))
+            assertEquals(expected = "-Infinity", actual = formatter.format(Double.NEGATIVE_INFINITY))
+        }
+    }
+
+    @Test
+    fun fixed_outOfRangePrecision_throws() {
+        // Assert
+        for (precision in listOf(Int.MIN_VALUE, -1, 16, Int.MAX_VALUE)) {
+            assertFailsWith<IllegalArgumentException> {
+                ChartValueFormatters.fixed(precision)
+            }
+        }
+    }
+
+    @Test
+    fun customFormatter_receivesDoubleWithoutNarrowing() {
+        val formatter = ChartValueFormatter { value: Double -> "value=${value - 16_777_217.0}" }
+        assertEquals(expected = "value=0.125", actual = formatter.format(16_777_217.125))
     }
 }

--- a/release-notes/3.0.0/changes/shared-chart-contracts.md
+++ b/release-notes/3.0.0/changes/shared-chart-contracts.md
@@ -1,0 +1,5 @@
+# PR Changeset
+
+- type: `feat`
+- module: `charts-core`
+- release_note: `Standardized the shared v3 data and value-formatter APIs on Double-only inputs, with explicit category labels and immutable data snapshots. Added composition-aware selection callbacks that notify only on actual changes, overflow-safe decimal formatting, and pie selection callback/timeout ownership fixes. Legacy chart dataset inputs and the existing PieSlice API remain unchanged in this step.`

--- a/release-notes/3.0.0/migrations/shared-chart-contracts.md
+++ b/release-notes/3.0.0/migrations/shared-chart-contracts.md
@@ -1,0 +1,85 @@
+# Shared v3 chart contracts
+
+This step finalizes the shared data, formatting, and selection foundation before the individual chart migrations. It changes the provisional APIs introduced in v3 snapshots. It does not replace the legacy `ChartDataSet` / `MultiChartDataSet` parameters of existing charts yet.
+
+## One value type: Double
+
+The shared v3 API accepts **Double only**, not separate String, Int, Float, or generic Number inputs. `ChartSeries.values` and `ChartValueFormatter.format` now use Double, and `toChartData()` is an extension on `List<Double>` only.
+
+```kotlin
+// Before: provisional v3 snapshot API
+val series = ChartSeries(name = "Sales", values = listOf(24f, 18f))
+val data = listOf(24f, 18f).toChartData()
+
+// After
+val series = ChartSeries(name = "Sales", values = listOf(24.0, 18.0))
+val data = listOf(24.0, 18.0).toChartData()
+```
+
+Convert or parse external values at the application boundary, before constructing chart data:
+
+```kotlin
+val dataFromInts = integerValues.map { it.toDouble() }.toChartData()
+val dataFromFloats = floatValues.map { it.toDouble() }.toChartData()
+val dataFromStrings = stringValues.map { text ->
+    requireNotNull(text.toDoubleOrNull()?.takeIf { it.isFinite() }) {
+        "Invalid chart value: $text"
+    }
+}.toChartData()
+```
+
+Choose an appropriate application error policy for invalid strings; the library does not infer parsing, locale, or missing-value behavior. Widening a Float does not recover precision already lost. The immutable models copy supplied lists; changing those original lists does not update a chart. Replace data instead. Models do not enforce chart-specific lengths or value ranges; each chart's validation remains responsible for those rules.
+
+Legacy v2 numeric/string dataset conversions remain while their charts still consume them. They are not new v3 input alternatives. Pie still uses its existing `PieSlice` entity with a Float value in this PR; a separate numeric alignment is planned before v3 stabilization. Do not pass the new `ChartData` to a chart that has not migrated its public signature.
+
+## Categories are explicit
+
+`toChartData()` no longer invents index-string labels. Empty categories mean no explicit labels, matching `ChartData()` and `chartDataOf()` defaults. Nonempty categories describe the shared indexed dimension and must match each series' length.
+
+```kotlin
+val values = listOf(24.0, 18.0)
+val data = values.toChartData(categories = listOf("Mon", "Tue"), seriesName = "Sales")
+
+// Explicitly request index labels if needed.
+val indexed = values.toChartData(categories = values.indices.map(Int::toString))
+```
+
+Series names are display names, not unique identities. Categories are labels, not numeric X coordinates. Title and formatting are separate from this shared table; legacy labels, prefix/postfix, and title must be migrated deliberately with each chart.
+
+## Selection callbacks
+
+`ChartSelection` notifies after an actual selection change. Selecting the same index twice or clearing an already empty selection no longer emits duplicate events. Construction and callback replacement do not emit events.
+
+```kotlin
+val selection = rememberChartSelection(
+    initialIndex = null,
+    onSelectionChanged = { index -> onPointSelected(index) },
+)
+```
+
+The holder is remembered; a new `initialIndex` on recomposition does not reset it. The callback above always uses the latest callback from composition without recreating the holder. Non-composable consumers can pass the callback to `ChartSelection(...)`. Explicitly assigning its `onSelectionChanged` property overrides the factory callback.
+
+Selection indices refer to source data. Bounds checking and chart-specific reset/gesture policies belong to the chart. `staticChartSelection(index)` creates ordinary mutable state initialized to that index; it does not lock selection or disable animation/interaction.
+
+Pie continues to take selection through `PieChartDefaults.style(selection = selection)`. It now redirects taps to a replacement holder and cancels the previous holder's pending deselection timer. Repeated taps still drive the interaction timeout independently of deduplicated selection notifications. No pie geometry or public parameter redesign is included.
+
+## Value formatting
+
+Custom formatters receive Double:
+
+```kotlin
+val formatter = ChartValueFormatter { value: Double -> "$value units" }
+val fixed = ChartValueFormatters.fixed(2)
+fixed.format(3.0) // "3.00"
+ChartValueFormatters.fixed(0).format(3.7) // "4", previously "4.0"
+ChartValueFormatters.Default.format(3.0) // "3.0"
+```
+
+- `fixed(precision)` supports `0..15` fractional digits and pads exactly that many. Values outside this precision range throw `IllegalArgumentException`.
+- Default formatting rounds to two fractional digits, trims trailing zeros, and keeps `.0` for integers. Prefix/suffix factories use the same default formatter.
+- Decimal ties round half away from zero. Negative values near zero display unsigned zero; negative ties no longer follow the old integer-rounding asymmetry.
+- Formatting manipulates the Double's decimal string rather than scaling into an Int/Long, so large finite values do not saturate or overflow. Scientific notation is expanded into decimal output.
+- NaN and infinities display as `NaN`, `Infinity`, and `-Infinity`; these strings are not permission for a chart to render invalid numeric data.
+- Rounding follows the platform's `Double.toString()` decimal representation, not its exact binary fraction. Last-digit representation differences can affect boundary rounding across platforms. Applications needing a stricter domain-specific formatting policy can supply their own formatter.
+
+Legacy chart-axis formatting is not switched to this formatter until each chart migrates. Review these intentional shared API breaks through the normal v3 `breaking-change` workflow; do not reset API baselines manually.


### PR DESCRIPTION
## Summary

Resolves the shared v3 chart contracts before any individual chart migration.

- `ChartSeries` and `ChartValueFormatter` use `Double` only. `toChartData()` is an extension on `List<Double>` with empty default categories.
- `ChartSelection` notifies only after an actual selection change. Repeated `select` or `clear` of the current value is a no-op. `rememberChartSelection` accepts a callback that always reads the latest value from composition without recreating the holder.
- `ChartValueFormatters.fixed` accepts `0..15` and pads exactly. Default rounds half away from zero using decimal-string rounding that handles large finite values and explicit `NaN` / `Infinity` strings.
- Pie now reads its tap callback through `rememberUpdatedState`, so a replaced selection holder receives gestures. The auto-deselect `LaunchedEffect` keys to `(points, selection, nonce)` so a holder swap cancels the previous timer.

## Breaking changes

- `ChartSeries.values: ImmutableList<Float>` is now `ImmutableList<Double>`. Existing call sites need an explicit `.toDouble()` widening at the application boundary.
- `List<Float>.toChartData()` is removed; only `List<Double>.toChartData()` remains. Float inputs must widen first.
- `ChartValueFormatter.format(value: Float)` is now `format(value: Double)`. Custom formatters need the parameter type changed.
- `ChartValueFormatters.fixed(precision)` requires `0 <= precision <= 15` (was `>= 0`). `fixed(0)` now returns `"4"` for `3.7` instead of `"4.0"`.
- `ChartSelection.select` and `clear` no longer notify when the value would not change. `rememberChartSelection` reads the latest callback via `rememberUpdatedState`; explicit `onSelectionChanged` assignments still override the factory callback.
- `staticChartSelection(index)` is initialized mutable state, not fixed state. It does not disable interaction or animation.

Legacy `ChartDataSet` / `MultiChartDataSet` numeric overloads remain in place; each chart migration removes them when its consumers are migrated.

## Validation

- `./gradlew ciCompile` (JVM, Wasm, Android production) passes.
- `./gradlew :charts:compileTestKotlinJvm :charts-pie:compileTestKotlinJvm :charts:compileTestKotlinWasmJs :charts-pie:compileTestKotlinWasmJs` pass.
- `./gradlew :charts-core:ktlintCheck :charts-pie:ktlintCheck :charts:ktlintCheck` pass.
- Tests, screenshots, and the API compatibility gate run on CI per the existing `breaking-change` workflow.