### PR TITLE
feat(line): migrate single and multi-line charts to v3 API

### DIFF
--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/LineChart.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/LineChart.kt
@@ -1,88 +1,163 @@
 package io.github.dautovicharis.charts
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import io.github.dautovicharis.charts.internal.NO_SELECTION
+import io.github.dautovicharis.charts.internal.common.composable.ChartErrors
+import io.github.dautovicharis.charts.internal.common.model.ChartDataItem
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
 import io.github.dautovicharis.charts.internal.linechart.LineChartImpl
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.MultiChartDataSet
+import io.github.dautovicharis.charts.internal.linechart.toInternal
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSelection
+import io.github.dautovicharis.charts.model.ChartValueFormatter
+import io.github.dautovicharis.charts.model.rememberChartSelection
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import io.github.dautovicharis.charts.style.LineChartStyle
+import kotlinx.collections.immutable.toImmutableList
+import io.github.dautovicharis.charts.internal.common.model.ChartData as InternalChartData
 
 /**
- * A composable function that displays a Line Chart with a single data set.
- *
- * @param dataSet The data set to be displayed in the chart.
- * @param style The style to be applied to the chart. If not provided, the default style will be used.
- * @param interactionEnabled Enables touch interactions (drag selection). Defaults to true.
- * Ignored when [renderMode] is [LineChartRenderMode.Timeline].
- * @param animateOnStart Enables initial chart animations. Defaults to true.
- * @param renderMode Chart transition mode. Defaults to [LineChartRenderMode.Morph].
- * @param animationDurationMillis Timeline transition duration. Used only when [renderMode]
- * is [LineChartRenderMode.Timeline].
- * @param selectedPointIndex Optional preselected point index for deterministic rendering (e.g. screenshots).
- * Dense zoom/scroll style settings are applied in morph mode and ignored in timeline mode.
+ * Displays one or more aligned indexed series. A single public entry point handles both
+ * single- and multi-line data. Selection always refers to a source X index shared by all series.
  */
 @Composable
 fun LineChart(
-    dataSet: ChartDataSet,
+    data: ChartData,
+    modifier: Modifier = Modifier,
     style: LineChartStyle = LineChartDefaults.style(),
+    title: String? = null,
+    selection: ChartSelection = rememberChartSelection(),
     interactionEnabled: Boolean = true,
     animateOnStart: Boolean = true,
     renderMode: LineChartRenderMode = LineChartRenderMode.Morph,
     animationDurationMillis: Int = 420,
-    selectedPointIndex: Int = NO_SELECTION,
+    valueFormatter: ChartValueFormatter = LineChartDefaults.valueFormatter,
+    axisValueFormatter: ChartValueFormatter = LineChartDefaults.axisValueFormatter,
 ) {
-    val data =
-        remember(dataSet) {
-            MultiChartData(
-                items = listOf(dataSet.data),
-                title = dataSet.data.label,
-            )
+    val errors = remember(data, style) { validateLineInput(data, style) }
+    val pointCount =
+        data.series
+            .firstOrNull()
+            ?.values
+            ?.size ?: 0
+    val selectedIndex = selection.selectedIndex?.takeIf { it in 0 until pointCount } ?: NO_SELECTION
+    val previousData = remember(selection) { mutableStateOf<ChartData?>(null) }
+    LaunchedEffect(data) {
+        val oldData = previousData.value
+        if (oldData != null && oldData != data) selection.clear()
+        previousData.value = data
+    }
+    if (errors.isNotEmpty()) {
+        ChartErrors(style.chartContainerStyle, errors.toImmutableList(), modifier)
+        return
+    }
+    val internalData =
+        remember(data, title, valueFormatter) {
+            toInternalLineData(data, title, valueFormatter)
         }
     LineChartImpl(
-        data = data,
-        style = style,
+        data = internalData,
+        style = style.toInternal(modifier),
         interactionEnabled = interactionEnabled,
         animateOnStart = animateOnStart,
         renderMode = renderMode,
         animationDurationMillis = animationDurationMillis,
-        selectedPointIndex = selectedPointIndex,
+        selectedPointIndex = selectedIndex,
+        onValueChanged = { index ->
+            if (index == NO_SELECTION) selection.clear() else selection.select(index)
+        },
+        valueFormatter = valueFormatter,
+        axisValueFormatter = axisValueFormatter,
+        selectedTitle =
+            if (selectedIndex == NO_SELECTION) {
+                null
+            } else if (data.series.size == 1) {
+                val value = valueFormatter.format(data.series.single().values[selectedIndex])
+                data.categories.getOrNull(selectedIndex)?.let { "$it: $value" } ?: value
+            } else {
+                data.categories.getOrNull(selectedIndex)
+            },
     )
 }
 
-/**
- * A composable function that displays a Line Chart with multiple data sets.
- *
- * @param dataSet The data sets to be displayed in the chart.
- * @param style The style to be applied to the chart. If not provided, the default style will be used.
- * @param interactionEnabled Enables touch interactions (drag selection). Defaults to true.
- * Ignored when [renderMode] is [LineChartRenderMode.Timeline].
- * @param animateOnStart Enables initial chart animations. Defaults to true.
- * @param renderMode Chart transition mode. Defaults to [LineChartRenderMode.Morph].
- * @param animationDurationMillis Timeline transition duration. Used only when [renderMode]
- * is [LineChartRenderMode.Timeline].
- * @param selectedPointIndex Optional preselected point index for deterministic rendering (e.g. screenshots).
- * Dense zoom/scroll style settings are applied in morph mode and ignored in timeline mode.
- */
-@Composable
-fun LineChart(
-    dataSet: MultiChartDataSet,
-    style: LineChartStyle = LineChartDefaults.style(),
-    interactionEnabled: Boolean = true,
-    animateOnStart: Boolean = true,
-    renderMode: LineChartRenderMode = LineChartRenderMode.Morph,
-    animationDurationMillis: Int = 420,
-    selectedPointIndex: Int = NO_SELECTION,
-) {
-    LineChartImpl(
-        data = dataSet.data,
-        style = style,
-        interactionEnabled = interactionEnabled,
-        animateOnStart = animateOnStart,
-        renderMode = renderMode,
-        animationDurationMillis = animationDurationMillis,
-        selectedPointIndex = selectedPointIndex,
+private fun validateLineInput(
+    data: ChartData,
+    style: LineChartStyle,
+): List<String> {
+    val errors = mutableListOf<String>()
+    if (data.series.isEmpty()) return listOf("At least one line series is required.")
+    val pointCount =
+        data.series
+            .first()
+            .values.size
+    if (pointCount < 2) errors += "At least two line values are required."
+    if (data.categories.isNotEmpty() && data.categories.size != pointCount) {
+        errors += "Category count (${data.categories.size}) must match value count ($pointCount)."
+    }
+    if (style.line.colors.isNotEmpty() && style.line.colors.size != data.series.size) {
+        errors += "Line color count must match series count (${data.series.size})."
+    }
+    data.series.forEachIndexed { index, series ->
+        if (series.values.size != pointCount) errors += "Series $index is not aligned with the first series."
+        if (data.categories.isNotEmpty() &&
+            series.values.size != data.categories.size &&
+            errors.none { it.startsWith("Category count") }
+        ) {
+            errors += "Category count (${data.categories.size}) must match every series value count."
+        }
+        if (series.values.any { !it.isFinite() }) errors += "Series $index contains a non-finite value."
+    }
+    if (!style.line.alpha.isFinite() || style.line.alpha !in 0f..1f) errors += "Line alpha must be in 0..1."
+    if (!style.line.strokeWidth.value
+            .isFinite() ||
+        style.line.strokeWidth.value < 0f
+    ) {
+        errors += "Line stroke width must be finite and nonnegative."
+    }
+    if (style.axis.xLabels.count < 2 ||
+        style.axis.yLabels.count < 2
+    ) {
+        errors += "Axis label counts must be at least two."
+    }
+    return errors
+}
+
+private fun toInternalLineData(
+    data: ChartData,
+    title: String?,
+    formatter: ChartValueFormatter,
+): MultiChartData {
+    val categories = data.categories
+    val items =
+        data.series.map { series ->
+            val labels =
+                when {
+                    data.series.size == 1 && categories.isNotEmpty() -> categories
+                    data.series.size == 1 -> emptyList()
+                    else -> series.values.map(formatter::format)
+                }
+            ChartDataItem(
+                label = series.name.orEmpty(),
+                item =
+                    InternalChartData(
+                        series.values.mapIndexed { index, value ->
+                            labels.getOrNull(index).orEmpty() to
+                                value
+                        },
+                    ),
+            )
+        }
+    return MultiChartData(
+        items = items,
+        categories = categories.takeIf { data.series.size > 1 }.orEmpty(),
+        title =
+            title ?: data.series
+                .firstOrNull()
+                ?.name
+                .orEmpty(),
     )
 }

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/LineChartPreviews.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/LineChartPreviews.kt
@@ -4,9 +4,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.github.dautovicharis.charts.LineChart
-import io.github.dautovicharis.charts.model.toChartDataSet
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.toChartData
 import io.github.dautovicharis.charts.style.ChartContainerDefaults
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import io.github.dautovicharis.charts.style.LineChartStyle
@@ -37,17 +37,16 @@ private val MULTI_LINE_INVALID_VALUES =
 @Composable
 private fun lineStyle(lineColors: List<Color>): LineChartStyle =
     LineChartDefaults.style(
-        bezier = true,
-        lineColors = lineColors,
-        dragPointSize = 5f,
-        pointVisible = true,
+        line = LineChartDefaults.line(colors = lineColors, bezier = true),
+        points = LineChartDefaults.points(size = 9.dp, visible = true),
+        selection = LineChartDefaults.selection(size = 5.dp),
         chartContainerStyle = ChartContainerDefaults.style(width = 300.dp),
     )
 
 @Composable
 private fun LineChartPreviewContent() {
     LineChart(
-        dataSet = SIMPLE_LINE_VALUES.toChartDataSet(title = LINE_CHART_TITLE),
+        data = SIMPLE_LINE_VALUES.map(Float::toDouble).toChartData(seriesName = LINE_CHART_TITLE),
         style = lineStyle(lineColors = listOf(MaterialTheme.colorScheme.primary)),
     )
 }
@@ -62,11 +61,13 @@ private fun MultiLineChartPreviewContent() {
             MaterialTheme.colorScheme.error,
         )
     LineChart(
-        dataSet =
-            MULTI_LINE_VALUES.toMultiChartDataSet(
-                title = LINE_CHART_TITLE,
+        data =
+            chartDataOf(
                 categories = CATEGORIES,
-                prefix = VALUE_PREFIX,
+                *MULTI_LINE_VALUES
+                    .map { (name, values) ->
+                        ChartSeries(name, values.map(Float::toDouble))
+                    }.toTypedArray(),
             ),
         style = lineStyle(lineColors = colors),
     )
@@ -99,11 +100,13 @@ private fun MultiLineChartErrorPreview() {
         )
     ChartsPreviewTheme {
         LineChart(
-            dataSet =
-                MULTI_LINE_INVALID_VALUES.toMultiChartDataSet(
-                    title = LINE_CHART_TITLE,
+            data =
+                chartDataOf(
                     categories = CATEGORIES.dropLast(1),
-                    prefix = VALUE_PREFIX,
+                    *MULTI_LINE_INVALID_VALUES
+                        .map { (name, values) ->
+                            ChartSeries(name, values.map(Float::toDouble))
+                        }.toTypedArray(),
                 ),
             style = lineStyle(lineColors = colors),
         )

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/LineValidation.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/LineValidation.kt
@@ -2,12 +2,12 @@ package io.github.dautovicharis.charts.internal
 
 import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_LINE
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
-import io.github.dautovicharis.charts.style.LineChartStyle
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
 
 @InternalChartsApi
 fun validateLineData(
     data: MultiChartData,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
 ): List<String> {
     val firstPointsSize =
         data.items

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
@@ -6,13 +6,14 @@ import androidx.compose.ui.graphics.Color
 import io.github.dautovicharis.charts.LineChartRenderMode
 import io.github.dautovicharis.charts.internal.NO_SELECTION
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
-import io.github.dautovicharis.charts.style.LineChartStyle
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
+import io.github.dautovicharis.charts.model.ChartValueFormatter
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 internal fun LineChart(
     data: MultiChartData,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     colors: ImmutableList<Color>,
     interactionEnabled: Boolean,
     animateOnStart: Boolean,
@@ -23,6 +24,8 @@ internal fun LineChart(
     zoomScale: Float = 1f,
     selectedPointIndex: Int = NO_SELECTION,
     onValueChanged: (Int) -> Unit = {},
+    valueFormatter: ChartValueFormatter,
+    axisValueFormatter: ChartValueFormatter,
 ) {
     LineChartContent(
         data = data,
@@ -37,5 +40,7 @@ internal fun LineChart(
         zoomScale = zoomScale,
         selectedPointIndex = selectedPointIndex,
         onValueChanged = onValueChanged,
+        valueFormatter = valueFormatter,
+        axisValueFormatter = axisValueFormatter,
     )
 }

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartAxis.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartAxis.kt
@@ -13,6 +13,7 @@ import io.github.dautovicharis.charts.internal.common.axis.AxisYLayoutTick
 import io.github.dautovicharis.charts.internal.common.axis.buildNumericYAxisTicks
 import io.github.dautovicharis.charts.internal.common.axis.resolveAxisLabel
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
+import io.github.dautovicharis.charts.model.ChartValueFormatter
 
 internal data class LineAxisTick(
     val label: String,
@@ -64,6 +65,7 @@ internal fun resolveLineXAxisLabels(data: MultiChartData): List<String> =
                 ?.item
                 ?.labels
                 ?.toList()
+                ?.takeUnless { labels -> labels.all(String::isBlank) }
                 .orEmpty()
         data.hasCategories() -> data.categories.toList()
         else -> emptyList()
@@ -104,6 +106,12 @@ internal fun buildLineYAxisTicks(
     labelCount: Int,
     plotHeightPx: Float,
     verticalInsetPx: Float = 0f,
+    formatter: ChartValueFormatter =
+        ChartValueFormatter { value ->
+            io.github.dautovicharis.charts.model.ChartValueFormatters.Default
+                .format(value)
+                .removeSuffix(".0")
+        },
 ): List<LineYAxisTick> =
     buildNumericYAxisTicks(
         minValue = minValue,
@@ -113,7 +121,7 @@ internal fun buildLineYAxisTicks(
         verticalInsetPx = verticalInsetPx,
     ).map { tick ->
         LineYAxisTick(
-            label = tick.label,
+            label = tick.label.toDoubleOrNull()?.let(formatter::format) ?: tick.label,
             centerY = tick.centerY,
         )
     }

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartContent.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartContent.kt
@@ -52,7 +52,8 @@ import io.github.dautovicharis.charts.internal.common.interaction.buildTapGestur
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
 import io.github.dautovicharis.charts.internal.common.model.minMax
 import io.github.dautovicharis.charts.internal.common.model.normalizeByMinMax
-import io.github.dautovicharis.charts.style.LineChartStyle
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
+import io.github.dautovicharis.charts.model.ChartValueFormatter
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -92,7 +93,7 @@ internal data class LineChartUpdateDecision(
 @Composable
 internal fun LineChartContent(
     data: MultiChartData,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     colors: ImmutableList<Color>,
     interactionEnabled: Boolean,
     animateOnStart: Boolean,
@@ -103,6 +104,8 @@ internal fun LineChartContent(
     zoomScale: Float = 1f,
     selectedPointIndex: Int = NO_SELECTION,
     onValueChanged: (Int) -> Unit = {},
+    valueFormatter: ChartValueFormatter,
+    axisValueFormatter: ChartValueFormatter,
 ) {
     val isPreview = LocalInspectionMode.current
     var show by rememberShowState(isPreviewMode = isPreview || !animateOnStart)
@@ -136,6 +139,7 @@ internal fun LineChartContent(
     val targetNormalized = remember(rawSeries, minMax) { data.normalizeByMinMax(minMax, 0f) }
     val pointsCount = rawSeries.firstOrNull()?.size ?: 0
     val forcedSelectionIndex = selectedPointIndex.takeIf { it in 0 until pointsCount } ?: NO_SELECTION
+    // A preset is authoritative for initial rendering, but does not disable later interaction.
     val hasForcedSelection = forcedSelectionIndex != NO_SELECTION
     val reportedSelection = remember(forcedSelectionIndex) { mutableIntStateOf(forcedSelectionIndex) }
     val seriesCount = rawSeries.size
@@ -161,8 +165,8 @@ internal fun LineChartContent(
     val timelineRenderMinMax = remember { mutableStateOf<Pair<Double, Double>?>(null) }
     val isTimelineMode = renderMode == LineChartRenderMode.Timeline
     val denseMorphEnabled = isDenseMorphMode && !isTimelineMode
-    val dragInteractionEnabled = interactionEnabled && !isTimelineMode && !denseMorphEnabled && !hasForcedSelection
-    val tapInteractionEnabled = interactionEnabled && denseMorphEnabled && !hasForcedSelection
+    val dragInteractionEnabled = interactionEnabled && !isTimelineMode && !denseMorphEnabled
+    val tapInteractionEnabled = interactionEnabled && denseMorphEnabled
 
     LaunchedEffect(dragInteractionEnabled, tapInteractionEnabled, hasForcedSelection) {
         dragging.value = false
@@ -421,7 +425,14 @@ internal fun LineChartContent(
         val chartHeightPx = with(density) { chartHeight.toPx() }.coerceAtLeast(1f)
         val lineVerticalInsetPx = LINE_VERTICAL_SAFE_INSET.coerceAtMost(chartHeightPx / 2f)
         val yAxisTicks =
-            remember(minMax, chartHeightPx, style.yAxisLabelCount, showYAxisLabels, lineVerticalInsetPx) {
+            remember(
+                minMax,
+                chartHeightPx,
+                style.yAxisLabelCount,
+                showYAxisLabels,
+                lineVerticalInsetPx,
+                axisValueFormatter,
+            ) {
                 if (!showYAxisLabels) {
                     emptyList()
                 } else {
@@ -431,6 +442,7 @@ internal fun LineChartContent(
                         labelCount = style.yAxisLabelCount,
                         plotHeightPx = chartHeightPx,
                         verticalInsetPx = lineVerticalInsetPx,
+                        formatter = axisValueFormatter,
                     )
                 }
             }

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartDrawing.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartDrawing.kt
@@ -11,12 +11,12 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import io.github.dautovicharis.charts.internal.ANIMATION_TARGET
 import io.github.dautovicharis.charts.internal.NO_SELECTION
 import io.github.dautovicharis.charts.internal.common.bezier.cubicControlPointsForSegment
-import io.github.dautovicharis.charts.style.LineChartStyle
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
 import kotlinx.collections.immutable.ImmutableList
 
 internal fun DrawScope.drawChartPath(
     values: List<Float>,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     lineAnimationProgress: Float,
     markerRevealProgress: Float,
     bezierTension: Float,
@@ -105,7 +105,7 @@ internal fun DrawScope.drawChartPath(
 
     val lineStroke =
         Stroke(
-            width = LINE_STROKE_WIDTH,
+            width = style.lineStrokeWidth.coerceAtLeast(0.5f),
             cap = StrokeCap.Round,
             join = StrokeJoin.Round,
         )
@@ -151,7 +151,7 @@ internal fun DrawScope.drawChartPath(
 
 private fun DrawScope.tryDrawPathPoints(
     values: List<Float>,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     lineColor: Color,
     markerRevealProgress: Float,
     stepX: Float,
@@ -188,7 +188,7 @@ private fun DrawScope.tryDrawPathPoints(
 internal fun DrawScope.drawDragMarker(
     touchX: Float,
     values: List<Float>,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     lineColor: Color,
     bezierTension: Float,
 ) {
@@ -252,7 +252,7 @@ internal fun DrawScope.drawDragMarker(
 }
 
 internal fun resolveSelectionLineColor(
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     colors: ImmutableList<Color>,
 ): Color =
     when (style.dragPointColorSameAsLine) {

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartHeader.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartHeader.kt
@@ -6,12 +6,12 @@ import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.common.composable.ChartHeaderLayout
 import io.github.dautovicharis.charts.internal.common.composable.DenseToggleControl
 import io.github.dautovicharis.charts.internal.common.composable.ZoomControls
-import io.github.dautovicharis.charts.style.LineChartStyle
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
 
 @Composable
 internal fun LineChartHeader(
     title: String,
-    style: LineChartStyle,
+    style: LineChartInternalStyle,
     showDensityToggle: Boolean,
     denseExpanded: Boolean,
     onToggleDensity: () -> Unit,

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartImpl.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartImpl.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -21,9 +20,8 @@ import io.github.dautovicharis.charts.internal.common.composable.zoomInScale
 import io.github.dautovicharis.charts.internal.common.composable.zoomOutScale
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
 import io.github.dautovicharis.charts.internal.common.palette.generateColorShades
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
 import io.github.dautovicharis.charts.internal.validateLineData
-import io.github.dautovicharis.charts.style.LineChartDefaults
-import io.github.dautovicharis.charts.style.LineChartStyle
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
@@ -34,12 +32,16 @@ private const val LINE_ZOOM_STEP = 1.25f
 @Composable
 internal fun LineChartImpl(
     data: MultiChartData,
-    style: LineChartStyle = LineChartDefaults.style(),
+    style: LineChartInternalStyle,
     interactionEnabled: Boolean = true,
     animateOnStart: Boolean = true,
     renderMode: LineChartRenderMode = LineChartRenderMode.Morph,
     animationDurationMillis: Int = 420,
     selectedPointIndex: Int = NO_SELECTION,
+    onValueChanged: (Int) -> Unit = {},
+    valueFormatter: io.github.dautovicharis.charts.model.ChartValueFormatter,
+    axisValueFormatter: io.github.dautovicharis.charts.model.ChartValueFormatter,
+    selectedTitle: String? = null,
 ) {
     val errors =
         remember(data, style) {
@@ -51,7 +53,6 @@ internal fun LineChartImpl(
 
     if (errors.isEmpty()) {
         val isTimelineMode = renderMode == LineChartRenderMode.Timeline
-        var selectedIndexFromInteraction by remember(data) { mutableIntStateOf(NO_SELECTION) }
         val sourcePointsCount = remember(data) { data.getFirstPointsSize() }
         val isDenseMorphData =
             remember(renderMode, sourcePointsCount) {
@@ -68,23 +69,12 @@ internal fun LineChartImpl(
                 }
             }
         val renderDataPointsCount = renderData.getFirstPointsSize()
-        val forcedSelectedIndex =
-            if (isTimelineMode) {
-                NO_SELECTION
-            } else {
-                selectedPointIndex.takeIf { it in 0 until renderDataPointsCount }
-                    ?: NO_SELECTION
-            }
-        val selectedInteractionIndex =
-            selectedIndexFromInteraction.takeIf { it in 0 until renderDataPointsCount } ?: NO_SELECTION
-        val effectiveSelectedIndex =
-            when (forcedSelectedIndex) {
-                NO_SELECTION -> selectedInteractionIndex
-                else -> forcedSelectedIndex
-            }
+        val effectiveSelectedIndex = selectedPointIndex.takeIf { it in 0 until renderDataPointsCount } ?: NO_SELECTION
         val title =
-            remember(renderData, effectiveSelectedIndex) {
-                renderData.getLabel(effectiveSelectedIndex)
+            if (effectiveSelectedIndex != NO_SELECTION) {
+                selectedTitle ?: renderData.getLabel(effectiveSelectedIndex)
+            } else {
+                renderData.title
             }
         val labels =
             remember(renderData, effectiveSelectedIndex, isTimelineMode) {
@@ -162,12 +152,11 @@ internal fun LineChartImpl(
                 isDenseMorphMode = isDenseMorphMode,
                 scrollState = scrollState,
                 zoomScale = zoomScale,
-                selectedPointIndex = forcedSelectedIndex,
-            ) { selectedIndex ->
-                if (forcedSelectedIndex == NO_SELECTION && selectedIndexFromInteraction != selectedIndex) {
-                    selectedIndexFromInteraction = selectedIndex
-                }
-            }
+                selectedPointIndex = effectiveSelectedIndex,
+                valueFormatter = valueFormatter,
+                axisValueFormatter = axisValueFormatter,
+                onValueChanged = { selectedIndex -> onValueChanged(selectedIndex) },
+            )
 
             if (renderData.hasCategories() || isTimelineMode) {
                 Legend(

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartInternalStyle.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartInternalStyle.kt
@@ -1,0 +1,42 @@
+package io.github.dautovicharis.charts.internal.linechart
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.TextUnit
+import io.github.dautovicharis.charts.internal.InternalChartsApi
+import io.github.dautovicharis.charts.style.ChartContainerStyle
+
+/** Flat renderer style retained temporarily behind the grouped v3 line API. */
+@InternalChartsApi
+@Immutable
+class LineChartInternalStyle(
+    val modifier: Modifier,
+    val chartContainerStyle: ChartContainerStyle,
+    val dragPointColorSameAsLine: Boolean,
+    val pointColorSameAsLine: Boolean,
+    val pointColor: Color,
+    val pointVisible: Boolean,
+    val pointSize: Float,
+    val lineColor: Color,
+    val lineAlpha: Float,
+    val lineColors: List<Color>,
+    val bezier: Boolean,
+    val lineStrokeWidth: Float,
+    val dragPointSize: Float,
+    val dragPointVisible: Boolean,
+    val dragActivePointSize: Float,
+    val dragPointColor: Color,
+    val axisVisible: Boolean,
+    val axisColor: Color,
+    val axisLineWidth: Float,
+    val yAxisLabelsVisible: Boolean,
+    val yAxisLabelColor: Color,
+    val yAxisLabelSize: TextUnit,
+    val yAxisLabelCount: Int,
+    val xAxisLabelsVisible: Boolean,
+    val xAxisLabelColor: Color,
+    val xAxisLabelSize: TextUnit,
+    val xAxisLabelMaxCount: Int,
+    val zoomControlsVisible: Boolean,
+)

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartStyleAdapter.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartStyleAdapter.kt
@@ -1,0 +1,40 @@
+package io.github.dautovicharis.charts.internal.linechart
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.dautovicharis.charts.internal.InternalChartsApi
+import io.github.dautovicharis.charts.style.LineChartStyle
+
+@InternalChartsApi
+@Composable
+fun LineChartStyle.toInternal(modifier: Modifier = Modifier): LineChartInternalStyle =
+    LineChartInternalStyle(
+        modifier = modifier.then(chartContainerStyle.wrapContentChartModifier()),
+        chartContainerStyle = chartContainerStyle,
+        dragPointColorSameAsLine = false,
+        pointColorSameAsLine = false,
+        pointColor = points.color,
+        pointVisible = points.visible,
+        pointSize = points.size.value,
+        lineColor = line.color,
+        lineAlpha = line.alpha,
+        lineColors = line.colors.toList(),
+        bezier = line.bezier,
+        lineStrokeWidth = line.strokeWidth.value,
+        dragPointSize = selection.size.value,
+        dragPointVisible = selection.visible,
+        dragActivePointSize = selection.activeSize.value,
+        dragPointColor = selection.color,
+        axisVisible = axis.visible,
+        axisColor = axis.color,
+        axisLineWidth = axis.lineWidth.value,
+        yAxisLabelsVisible = axis.yLabels.visible,
+        yAxisLabelColor = axis.yLabels.color,
+        yAxisLabelSize = axis.yLabels.size,
+        yAxisLabelCount = axis.yLabels.count,
+        xAxisLabelsVisible = axis.xLabels.visible,
+        xAxisLabelColor = axis.xLabels.color,
+        xAxisLabelSize = axis.xLabels.size,
+        xAxisLabelMaxCount = axis.xLabels.count,
+        zoomControlsVisible = zoomControlsVisible,
+    )

--- a/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/style/LineChartStyle.kt
+++ b/charts-line/src/commonMain/kotlin/io/github/dautovicharis/charts/style/LineChartStyle.kt
@@ -3,188 +3,131 @@ package io.github.dautovicharis.charts.style
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.dautovicharis.charts.model.ChartValueFormatter
+import io.github.dautovicharis.charts.model.ChartValueFormatters
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
-/**
- * A class that defines the style for a Line Chart.
- *
- * @property modifier The modifier to be applied to the chart.
- * @property chartContainerStyle The style to be applied to the chart view.
- * @property dragPointColorSameAsLine A boolean indicating whether the color of the drag point is the same as the line color.
- * @property pointColorSameAsLine A boolean indicating whether the color of the point is the same as the line color.
- * @property pointColor The color of the points on the line chart.
- * @property pointVisible A boolean indicating whether the points on the line chart are visible.
- * @property pointSize The size of the points on the line chart.
- * @property lineColor The color of the line in the line chart.
- * @property lineAlpha The alpha value applied to rendered line colors.
- * @property lineColors The colors of the lines in the line chart.
- * @property bezier A boolean indicating whether the line chart should be drawn with bezier curves.
- * @property dragPointSize The size of the drag point on the line chart.
- * @property dragPointVisible A boolean indicating whether the drag point on the line chart is visible.
- * @property dragActivePointSize The size of the active drag point on the line chart.
- * @property dragPointColor The color of the drag point on the line chart.
- * @property axisVisible Whether chart axes are shown.
- * @property axisColor The color of the axes.
- * @property axisLineWidth The stroke width of the axes.
- * @property yAxisLabelsVisible Whether Y-axis labels are shown.
- * @property yAxisLabelColor The color of Y-axis labels.
- * @property yAxisLabelSize The text size of Y-axis labels.
- * @property yAxisLabelCount Number of Y-axis labels.
- * @property xAxisLabelsVisible Whether X-axis labels are shown.
- * @property xAxisLabelColor The color of X-axis labels.
- * @property xAxisLabelSize The text size of X-axis labels.
- * @property xAxisLabelMaxCount Maximum number of X-axis labels to display.
- * @property zoomControlsVisible Whether dense-mode zoom controls are shown.
- */
+@Immutable
+data class LineVisualStyle(
+    val color: Color,
+    val alpha: Float,
+    val colors: ImmutableList<Color>,
+    val strokeWidth: Dp,
+    val bezier: Boolean,
+) {
+    constructor(
+        color: Color,
+        alpha: Float,
+        colors: List<Color>,
+        strokeWidth: Dp,
+        bezier: Boolean,
+    ) : this(color, alpha, colors.toImmutableList(), strokeWidth, bezier)
+}
+
+@Immutable
+data class LinePointStyle(
+    val color: Color,
+    val size: Dp,
+    val visible: Boolean,
+)
+
+@Immutable
+data class LineSelectionStyle(
+    val color: Color,
+    val size: Dp,
+    val activeSize: Dp,
+    val visible: Boolean,
+)
+
+@Immutable
+data class LineAxisStyle(
+    val visible: Boolean,
+    val color: Color,
+    val lineWidth: Dp,
+    val xLabels: AxisLabelStyle,
+    val yLabels: AxisLabelStyle,
+)
+
+/** Grouped, Compose-friendly v3 style for single- and multi-line charts. */
 @Immutable
 class LineChartStyle(
-    val modifier: Modifier,
     val chartContainerStyle: ChartContainerStyle,
-    val dragPointColorSameAsLine: Boolean,
-    val pointColorSameAsLine: Boolean,
-    val pointColor: Color,
-    val pointVisible: Boolean,
-    val pointSize: Float,
-    val lineColor: Color,
-    val lineAlpha: Float,
-    val lineColors: List<Color>,
-    val bezier: Boolean,
-    val dragPointSize: Float,
-    val dragPointVisible: Boolean,
-    val dragActivePointSize: Float,
-    val dragPointColor: Color,
-    val axisVisible: Boolean,
-    val axisColor: Color,
-    val axisLineWidth: Float,
-    val yAxisLabelsVisible: Boolean,
-    val yAxisLabelColor: Color,
-    val yAxisLabelSize: TextUnit,
-    val yAxisLabelCount: Int,
-    val xAxisLabelsVisible: Boolean,
-    val xAxisLabelColor: Color,
-    val xAxisLabelSize: TextUnit,
-    val xAxisLabelMaxCount: Int,
+    val line: LineVisualStyle,
+    val points: LinePointStyle,
+    val selection: LineSelectionStyle,
+    val axis: LineAxisStyle,
     val zoomControlsVisible: Boolean,
 )
 
-/**
- * An object that provides default styles for a Line Chart.
- */
 object LineChartDefaults {
-    /**
-     * Returns the default color for points on a Line Chart.
-     */
-    @Composable
-    private fun defaultPointColor() = MaterialTheme.colorScheme.tertiary
-
-    /**
-     * Returns the default color for drag points on a Line Chart.
-     */
-    @Composable
-    private fun defaultDragPointColor() = MaterialTheme.colorScheme.tertiary
-
-    @Composable
-    private fun defaultAxisColor() = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-
-    @Composable
-    private fun defaultXAxisLabelColor() = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
-
-    @Composable
-    private fun defaultYAxisLabelColor() = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
-
-    /**
-     * Returns a LineChartStyle with the provided parameters or their default values.
-     *
-     * @param pointColor The color of the points on the line chart. Defaults to the tertiary color of the MaterialTheme.
-     * @param pointSize The size of the points on the line chart. Defaults to 9f.
-     * @param pointVisible A boolean indicating whether the points on the line chart are visible. Defaults to false.
-     * @param lineColor The color of the line in the line chart. Defaults to the primary color of the MaterialTheme.
-     * @param lineAlpha The alpha value applied to rendered line colors. Defaults to 0.4f in light theme and 0.6f in dark theme.
-     * @param lineColors The colors of the lines in the line chart. Defaults to an empty list.
-     * @param bezier A boolean indicating whether the line chart should be drawn with bezier curves. Defaults to true.
-     * @param dragPointSize The size of the drag point on the line chart. Defaults to 7f.
-     * @param dragPointVisible A boolean indicating whether the drag point on the line chart is visible. Defaults to true.
-     * @param dragActivePointSize The size of the active drag point on the line chart. Defaults to 12f.
-     * @param dragPointColor The color of the drag point on the line chart. Defaults to the tertiary color of the MaterialTheme.
-     * @param axisVisible Whether chart axes are shown. Defaults to true.
-     * @param axisColor The color of the axes. Defaults to a theme-based onSurface variant.
-     * @param axisLineWidth The stroke width of the axes. Defaults to 1f.
-     * @param yAxisLabelsVisible Whether Y-axis labels are shown. Defaults to true.
-     * @param yAxisLabelColor The color of Y-axis labels. Defaults to a theme-based onSurface variant.
-     * @param yAxisLabelSize The text size of Y-axis labels. Defaults to 11.sp.
-     * @param yAxisLabelCount Number of Y-axis labels. Defaults to 5.
-     * @param xAxisLabelsVisible Whether X-axis labels are shown. Defaults to true.
-     * @param xAxisLabelColor The color of X-axis labels. Defaults to a theme-based onSurface variant.
-     * @param xAxisLabelSize The text size of X-axis labels. Defaults to 11.sp.
-     * @param xAxisLabelMaxCount Maximum number of X-axis labels to display. Defaults to 6.
-     * @param zoomControlsVisible Whether dense-mode zoom controls are shown. Defaults to true.
-     * @param chartContainerStyle The style to be applied to the chart view. Defaults to the default style of ChartContainerDefaults.
-     *
-     * Dense zoom/scroll properties are applied in morph mode and ignored in timeline mode.
-     */
     @Composable
     fun style(
-        pointColor: Color = defaultPointColor(),
-        pointSize: Float = 9f,
-        pointVisible: Boolean = false,
-        lineColor: Color = MaterialTheme.colorScheme.primary,
-        lineAlpha: Float = defaultChartAlpha(),
-        lineColors: List<Color> = emptyList(),
-        bezier: Boolean = true,
-        dragPointSize: Float = 7f,
-        dragPointVisible: Boolean = true,
-        dragActivePointSize: Float = 12f,
-        dragPointColor: Color = defaultDragPointColor(),
-        axisVisible: Boolean = true,
-        axisColor: Color = defaultAxisColor(),
-        axisLineWidth: Float = 1f,
-        yAxisLabelsVisible: Boolean = true,
-        yAxisLabelColor: Color = defaultYAxisLabelColor(),
-        yAxisLabelSize: TextUnit = 11.sp,
-        yAxisLabelCount: Int = 5,
-        xAxisLabelsVisible: Boolean = true,
-        xAxisLabelColor: Color = defaultXAxisLabelColor(),
-        xAxisLabelSize: TextUnit = 11.sp,
-        xAxisLabelMaxCount: Int = 6,
-        zoomControlsVisible: Boolean = true,
         chartContainerStyle: ChartContainerStyle = ChartContainerDefaults.style(),
-    ): LineChartStyle {
-        val modifier: Modifier = chartContainerStyle.wrapContentChartModifier()
+        line: LineVisualStyle = line(),
+        points: LinePointStyle = points(),
+        selection: LineSelectionStyle = selection(),
+        axis: LineAxisStyle = axis(),
+        zoomControlsVisible: Boolean = true,
+    ): LineChartStyle = LineChartStyle(chartContainerStyle, line, points, selection, axis, zoomControlsVisible)
 
-        val pointColorSameAsLine = pointColor == defaultPointColor()
-        val dragPointColorSameAsLine = dragPointColor == defaultDragPointColor()
+    @Composable
+    fun line(
+        color: Color = MaterialTheme.colorScheme.primary,
+        alpha: Float = defaultChartAlpha(),
+        colors: List<Color> = emptyList(),
+        strokeWidth: Dp = 5.dp,
+        bezier: Boolean = true,
+    ): LineVisualStyle = LineVisualStyle(color, alpha.coerceIn(0f, 1f), colors, strokeWidth, bezier)
 
-        return LineChartStyle(
-            modifier = modifier,
-            pointColor = pointColor,
-            lineColor = lineColor,
-            lineAlpha = lineAlpha.coerceIn(0f, 1f),
-            bezier = bezier,
-            pointVisible = pointVisible,
-            lineColors = lineColors,
-            dragPointSize = dragPointSize,
-            dragPointVisible = dragPointVisible,
-            pointSize = pointSize,
-            dragActivePointSize = dragActivePointSize,
-            pointColorSameAsLine = pointColorSameAsLine,
-            dragPointColor = dragPointColor,
-            dragPointColorSameAsLine = dragPointColorSameAsLine,
-            axisVisible = axisVisible,
-            axisColor = axisColor,
-            axisLineWidth = axisLineWidth,
-            yAxisLabelsVisible = yAxisLabelsVisible,
-            yAxisLabelColor = yAxisLabelColor,
-            yAxisLabelSize = yAxisLabelSize,
-            yAxisLabelCount = yAxisLabelCount,
-            xAxisLabelsVisible = xAxisLabelsVisible,
-            xAxisLabelColor = xAxisLabelColor,
-            xAxisLabelSize = xAxisLabelSize,
-            xAxisLabelMaxCount = xAxisLabelMaxCount,
-            zoomControlsVisible = zoomControlsVisible,
-            chartContainerStyle = chartContainerStyle,
-        )
-    }
+    @Composable
+    fun points(
+        color: Color = MaterialTheme.colorScheme.tertiary,
+        size: Dp = 9.dp,
+        visible: Boolean = false,
+    ): LinePointStyle = LinePointStyle(color, size, visible)
+
+    @Composable
+    fun selection(
+        color: Color = MaterialTheme.colorScheme.tertiary,
+        size: Dp = 7.dp,
+        activeSize: Dp = 12.dp,
+        visible: Boolean = true,
+    ): LineSelectionStyle = LineSelectionStyle(color, size, activeSize, visible)
+
+    @Composable
+    fun axis(
+        visible: Boolean = true,
+        color: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+        lineWidth: Dp = 1.dp,
+        xLabels: AxisLabelStyle = xLabels(),
+        yLabels: AxisLabelStyle = yLabels(),
+    ): LineAxisStyle = LineAxisStyle(visible, color, lineWidth, xLabels, yLabels)
+
+    @Composable
+    fun xLabels(
+        visible: Boolean = true,
+        color: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+        size: TextUnit = 11.sp,
+        count: Int = 6,
+    ): AxisLabelStyle = AxisLabelStyle(visible, color, size, count)
+
+    @Composable
+    fun yLabels(
+        visible: Boolean = true,
+        color: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+        size: TextUnit = 11.sp,
+        count: Int = 5,
+    ): AxisLabelStyle = AxisLabelStyle(visible, color, size, count)
+
+    val valueFormatter: ChartValueFormatter = ChartValueFormatters.Default
+    val axisValueFormatter: ChartValueFormatter =
+        ChartValueFormatter { value ->
+            ChartValueFormatters.Default.format(value).removeSuffix(".0")
+        }
 }

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
@@ -1,10 +1,10 @@
 package io.github.dautovicharis.charts.mock
 
 import androidx.compose.ui.graphics.Color
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.MultiChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.toChartData
 
 internal object MockTest {
     const val TITLE = "Title"
@@ -17,31 +17,30 @@ internal object MockTest {
     private val categories = listOf("Jan", "Feb", "Mar", "Apr")
     val colors = listOf(Color.Red, Color.Green, Color.Cyan, Color.Black)
 
-    val dataSet: ChartDataSet =
-        listOf(10f, 20f, 30f, 40f).toChartDataSet(
-            title = TITLE,
-        )
+    val dataSet: ChartData =
+        listOf(10f, 20f, 30f, 40f)
+            .map { it.toDouble() }
+            .toChartData(seriesName = TITLE)
 
-    val multiDataSet: MultiChartDataSet =
-        listOf(
-            "Item 1" to firstItem,
-            "Item 2" to secondItem,
-            "Item 3" to thirdItem,
-            "Item 4" to fourthItem,
-        ).toMultiChartDataSet(
-            title = TITLE,
+    val multiDataSet: ChartData =
+        chartDataOf(
             categories = categories,
+            *arrayOf(
+                ChartSeries(name = "Item 1", values = firstItem.map { it.toDouble() }),
+                ChartSeries(name = "Item 2", values = secondItem.map { it.toDouble() }),
+                ChartSeries(name = "Item 3", values = thirdItem.map { it.toDouble() }),
+                ChartSeries(name = "Item 4", values = fourthItem.map { it.toDouble() }),
+            ),
         )
 
-    fun invalidMultiDataSet(): MultiChartDataSet =
-        listOf(
-            "Item 1" to firstItem.dropLast(1),
-            "Item 2" to secondItem,
-            "Item 3" to thirdItem.dropLast(1),
-            "Item 4" to fourthItem,
-        ).toMultiChartDataSet(
-            title = TITLE,
+    fun invalidMultiDataSet(): ChartData =
+        chartDataOf(
             categories = categories.dropLast(1),
-            prefix = "$",
+            *arrayOf(
+                ChartSeries(name = "Item 1", values = firstItem.dropLast(1).map { it.toDouble() }),
+                ChartSeries(name = "Item 2", values = secondItem.map { it.toDouble() }),
+                ChartSeries(name = "Item 3", values = thirdItem.dropLast(1).map { it.toDouble() }),
+                ChartSeries(name = "Item 4", values = fourthItem.map { it.toDouble() }),
+            ),
         )
 }

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartDenseDataTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartDenseDataTest.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
@@ -15,8 +15,8 @@ import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.internal.TestTags
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.toChartData
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
@@ -31,11 +31,11 @@ class LineChartDenseDataTest {
     fun lineChart_withLargeDataset_showsCompactToggleByDefault() =
         runComposeUiTest {
             setContent {
-                LineChart(dataSet = largeDataSet())
+                LineChart(data = largeDataSet())
             }
 
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_DENSE_EXPAND).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_DENSE_EXPAND).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -44,10 +44,10 @@ class LineChartDenseDataTest {
     fun lineChart_smallDataset_doesNotShowZoomControls() =
         runComposeUiTest {
             setContent {
-                LineChart(dataSet = smallDataSet())
+                LineChart(data = smallDataSet())
             }
 
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -57,7 +57,7 @@ class LineChartDenseDataTest {
         runComposeUiTest {
             setContent {
                 LineChart(
-                    dataSet = largeDataSet(),
+                    data = largeDataSet(),
                     style = LineChartDefaults.style(zoomControlsVisible = false),
                 )
             }
@@ -72,17 +72,21 @@ class LineChartDenseDataTest {
             val dataSet = largeDataSet(title = "Dense Line Chart")
             val currentDataSet = mutableStateOf(dataSet)
             setContent {
-                LineChart(dataSet = currentDataSet.value)
+                LineChart(data = currentDataSet.value)
             }
 
             onNodeWithTag(TestTags.LINE_CHART_DENSE_EXPAND).performTouchInput { click() }
-            onNodeWithTag(TestTags.LINE_CHART_DENSE_COLLAPSE).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_ZOOM_OUT).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_ZOOM_IN).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_DENSE_COLLAPSE).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_ZOOM_IN).assertIsDisplayed()
 
             tapChartAt(x = 24f)
             waitUntil(timeoutMillis = 3_000L) {
-                currentTitle() != dataSet.data.label
+                currentTitle() !=
+                    dataSet.series
+                        .first()
+                        .name
+                        .orEmpty()
             }
             val beforeScrollTitle = currentTitle()
 
@@ -94,12 +98,23 @@ class LineChartDenseDataTest {
             tapChartAt(x = 24f)
             waitUntil(timeoutMillis = 3_000L) {
                 val title = currentTitle()
-                title != beforeScrollTitle && title != dataSet.data.label
+                title != beforeScrollTitle &&
+                    title !=
+                    dataSet.series
+                        .first()
+                        .name
+                        .orEmpty()
             }
             val afterScrollTitle = currentTitle()
 
             assertNotEquals(beforeScrollTitle, afterScrollTitle)
-            assertNotEquals(dataSet.data.label, afterScrollTitle)
+            assertNotEquals(
+                dataSet.series
+                    .first()
+                    .name
+                    .orEmpty(),
+                afterScrollTitle,
+            )
         }
 
     private fun ComposeUiTest.currentTitle(): String {
@@ -124,30 +139,24 @@ class LineChartDenseDataTest {
         }
     }
 
-    private fun smallDataSet(points: Int = 12): ChartDataSet {
+    private fun smallDataSet(points: Int = 12): ChartData {
         val labels = dateLabels(points)
         val values = values(points)
-        return values.toChartDataSet(
-            title = "Small Line Chart",
-            labels = labels,
-        )
+        return values.toChartData(categories = labels, seriesName = "Small Line Chart")
     }
 
     private fun largeDataSet(
         points: Int = 120,
         title: String = "Large Line Chart",
-    ): ChartDataSet {
+    ): ChartData {
         val labels = dateLabels(points)
         val values = values(points)
-        return values.toChartDataSet(
-            title = title,
-            labels = labels,
-        )
+        return values.toChartData(categories = labels, seriesName = title)
     }
 
-    private fun values(points: Int): List<Float> =
+    private fun values(points: Int): List<Double> =
         List(points) { index ->
-            ((index % 30) - 10).toFloat()
+            ((index % 30) - 10).toDouble()
         }
 
     private fun dateLabels(points: Int): List<String> {

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartTest.kt
@@ -2,8 +2,8 @@ package io.github.dautovicharis.charts.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -12,14 +12,11 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.LineChartRenderMode
 import io.github.dautovicharis.charts.internal.TestTags
-import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_LINE
-import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN
-import io.github.dautovicharis.charts.internal.common.model.ChartDataType
-import io.github.dautovicharis.charts.internal.format
 import io.github.dautovicharis.charts.mock.MockTest.TITLE
 import io.github.dautovicharis.charts.mock.MockTest.dataSet
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.toChartData
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -30,20 +27,24 @@ class LineChartTest {
     fun lineChart_withValidData_displaysChart() =
         runComposeUiTest {
             // Arrange
-            val expectedTitle = dataSet.data.label
+            val expectedTitle =
+                dataSet.series
+                    .first()
+                    .name
+                    .orEmpty()
 
             // Act
             setContent {
-                LineChart(dataSet)
+                LineChart(data = dataSet)
             }
 
             // Assert
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE)
                 .assertTextEquals(expectedTitle)
-                .isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+                .assertIsDisplayed()
+            onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -51,25 +52,29 @@ class LineChartTest {
     fun lineChart_withTimelineRenderMode_displaysChart() =
         runComposeUiTest {
             // Arrange
-            val expectedTitle = dataSet.data.label
-            val expectedLegendCurrentValue = "${dataSet.data.label} - 40"
+            val expectedTitle =
+                dataSet.series
+                    .first()
+                    .name
+                    .orEmpty()
+            val expectedLegendCurrentValue = "$TITLE - 40.0"
 
             // Act
             setContent {
                 LineChart(
-                    dataSet = dataSet,
+                    data = dataSet,
                     renderMode = LineChartRenderMode.Timeline,
                 )
             }
 
             // Assert
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE)
                 .assertTextEquals(expectedTitle)
-                .isDisplayed()
+                .assertIsDisplayed()
             onAllNodesWithText(expectedLegendCurrentValue).assertCountEquals(0)
-            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+            onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -80,12 +85,12 @@ class LineChartTest {
         runComposeUiTest {
             setContent {
                 LineChart(
-                    dataSet = largeDataSet(),
+                    data = largeDataSet(),
                     renderMode = LineChartRenderMode.Timeline,
                 )
             }
 
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -96,13 +101,16 @@ class LineChartTest {
         runComposeUiTest {
             setContent {
                 LineChart(
-                    dataSet = dataSet,
-                    style = LineChartDefaults.style(xAxisLabelsVisible = false),
+                    data = dataSet,
+                    style =
+                        LineChartDefaults.style(
+                            axis = LineChartDefaults.axis(xLabels = LineChartDefaults.xLabels(visible = false)),
+                        ),
                 )
             }
 
             onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -111,12 +119,15 @@ class LineChartTest {
         runComposeUiTest {
             setContent {
                 LineChart(
-                    dataSet = dataSet,
-                    style = LineChartDefaults.style(yAxisLabelsVisible = false),
+                    data = dataSet,
+                    style =
+                        LineChartDefaults.style(
+                            axis = LineChartDefaults.axis(yLabels = LineChartDefaults.yLabels(visible = false)),
+                        ),
                 )
             }
 
-            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).isDisplayed()
+            onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertCountEquals(0)
         }
 
@@ -125,13 +136,15 @@ class LineChartTest {
     fun lineChart_lastXAxisLabel_hasRightEdgePadding() =
         runComposeUiTest {
             val edgeDataSet =
-                listOf(20f, 28f, 23f, 30f).toChartDataSet(
-                    title = "Quarterly Revenue by Region",
-                    labels = listOf("Region 4", "Region 36", "Region 68", "Region 100"),
-                )
+                listOf(20f, 28f, 23f, 30f)
+                    .map { it.toDouble() }
+                    .toChartData(
+                        seriesName = "Quarterly Revenue by Region",
+                        categories = listOf("Region 4", "Region 36", "Region 68", "Region 100"),
+                    )
 
             setContent {
-                LineChart(dataSet = edgeDataSet)
+                LineChart(data = edgeDataSet)
             }
 
             val axisBounds = onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).fetchSemanticsNode().boundsInRoot
@@ -145,27 +158,19 @@ class LineChartTest {
     @Test
     fun lineChart_withInvalidData_displaysError() =
         runComposeUiTest {
-            val dataSet =
-                ChartDataSet(
-                    items = ChartDataType.FloatData(listOf(1f)),
-                    title = TITLE,
-                )
-            val expectedError = RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_LINE)
+            val dataSet = ChartData(series = listOf(ChartSeries(name = TITLE, values = listOf(1.0))))
 
             setContent {
-                LineChart(dataSet)
+                LineChart(data = dataSet)
             }
 
-            onNodeWithTag(TestTags.CHART_ERROR).isDisplayed()
-            onNodeWithText("${expectedError}\n").isDisplayed()
+            onNodeWithTag(TestTags.CHART_ERROR).assertIsDisplayed()
+            onNodeWithText("At least two line values are required.", substring = true).assertIsDisplayed()
         }
 
-    private fun largeDataSet(points: Int = 120): ChartDataSet {
+    private fun largeDataSet(points: Int = 120): ChartData {
         val labels = List(points) { index -> "Point ${index + 1}" }
-        val values = List(points) { index -> (index % 25).toFloat() }
-        return values.toChartDataSet(
-            title = "Large Line Chart",
-            labels = labels,
-        )
+        val values = List(points) { index -> (index % 25).toDouble() }
+        return values.toChartData(categories = labels, seriesName = "Large Line Chart")
     }
 }

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartV3ContractTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartV3ContractTest.kt
@@ -1,0 +1,128 @@
+package io.github.dautovicharis.charts.ui
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import io.github.dautovicharis.charts.LineChart
+import io.github.dautovicharis.charts.internal.TestTags
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSelection
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.ChartValueFormatters
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.toChartData
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalTestApi::class)
+class LineChartV3ContractTest {
+    @Test
+    fun externalSelectionAndDataReplacement_areAuthoritative() =
+        runComposeUiTest {
+            val selection = ChartSelection()
+            val currentData = mutableStateOf(data(categories = listOf("A", "B", "C")))
+            setContent {
+                LineChart(
+                    data = currentData.value,
+                    title = "Line",
+                    selection = selection,
+                    animateOnStart = false,
+                )
+            }
+
+            runOnIdle { selection.select(1) }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("B: 20.0").assertIsDisplayed()
+            runOnIdle { selection.clear() }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("Line").assertIsDisplayed()
+
+            runOnIdle {
+                selection.select(1)
+                currentData.value = data(categories = listOf("X", "Y", "Z"))
+            }
+            waitForIdle()
+            runOnIdle { assertNull(selection.selectedIndex) }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("Line").assertIsDisplayed()
+        }
+
+    @Test
+    fun noCategories_selectionUsesFormattedRawValueAndDoesNotCreateXAxisLabels() =
+        runComposeUiTest {
+            val selection = ChartSelection(initialIndex = 1)
+            setContent {
+                LineChart(
+                    data = listOf(0.123456789, 42.0).toChartData(),
+                    selection = selection,
+                    animateOnStart = false,
+                )
+            }
+
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("42.0").assertIsDisplayed()
+            onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
+        }
+
+    @Test
+    fun formattersUpdateSelectedReadoutAndAxisIndependently() =
+        runComposeUiTest {
+            val selection = ChartSelection(initialIndex = 0)
+            val valueFormatter = mutableStateOf(ChartValueFormatters.Default)
+            val axisFormatter = mutableStateOf(ChartValueFormatters.Default)
+            val preciseData = listOf(0.123456789, 1.0).toChartData(categories = listOf("First", "Last"))
+            setContent {
+                LineChart(
+                    data = preciseData,
+                    selection = selection,
+                    valueFormatter = valueFormatter.value,
+                    axisValueFormatter = axisFormatter.value,
+                    animateOnStart = false,
+                )
+            }
+
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("First: 0.12").assertIsDisplayed()
+            runOnIdle { valueFormatter.value = ChartValueFormatters.suffix(" units") }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("First: 0.12 units").assertIsDisplayed()
+            runOnIdle { axisFormatter.value = { value -> "axis=$value" } }
+            onNodeWithText("axis=1.0").assertIsDisplayed()
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals("First: 0.12 units").assertIsDisplayed()
+        }
+
+    @Test
+    fun malformedDataPreservesModifierAndRendersErrorInsteadOfDrawing() =
+        runComposeUiTest {
+            val invalid =
+                chartDataOf(
+                    categories = listOf("A", "B"),
+                    ChartSeries(name = "First", values = listOf(1.0, 2.0)),
+                    ChartSeries(name = "Second", values = listOf(3.0)),
+                )
+            setContent {
+                LineChart(
+                    data = invalid,
+                    modifier = Modifier.testTag("line-container").size(280.dp, 240.dp),
+                    animateOnStart = false,
+                )
+            }
+
+            onNodeWithTag("line-container")
+                .assertIsDisplayed()
+                .assertWidthIsEqualTo(280.dp)
+                .assertHeightIsEqualTo(240.dp)
+            onNodeWithTag(TestTags.CHART_ERROR).assertIsDisplayed()
+            onAllNodesWithTag(TestTags.LINE_CHART).assertCountEquals(0)
+            onNodeWithText("Series 1 is not aligned", substring = true).assertIsDisplayed()
+        }
+
+    private fun data(categories: List<String>): ChartData =
+        listOf(10.0, 20.0, 30.0).toChartData(categories = categories, seriesName = "Series")
+}

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/MultiLineChartTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/MultiLineChartTest.kt
@@ -2,8 +2,8 @@ package io.github.dautovicharis.charts.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -12,13 +12,13 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.LineChartRenderMode
 import io.github.dautovicharis.charts.internal.TestTags
-import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_COLORS_SIZE_MISMATCH
-import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_ITEM_POINTS_SIZE
-import io.github.dautovicharis.charts.internal.format
 import io.github.dautovicharis.charts.mock.MockTest.colors
 import io.github.dautovicharis.charts.mock.MockTest.invalidMultiDataSet
 import io.github.dautovicharis.charts.mock.MockTest.multiDataSet
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.ChartValueFormatters
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.staticChartSelection
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import kotlin.test.Test
 
@@ -28,20 +28,20 @@ class MultiLineChartTest {
     fun multiLineChart_withValidData_displaysChart() =
         runComposeUiTest {
             // Arrange
-            val expectedTitle = multiDataSet.data.title
+            val expectedTitle = "Title"
 
             // Act
             setContent {
-                LineChart(multiDataSet)
+                LineChart(data = multiDataSet, title = expectedTitle)
             }
 
             // Assert
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE)
                 .assertTextEquals(expectedTitle)
-                .isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+                .assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -49,25 +49,27 @@ class MultiLineChartTest {
     fun multiLineChart_withTimelineRenderMode_displaysChart() =
         runComposeUiTest {
             // Arrange
-            val expectedTitle = multiDataSet.data.title
-            val expectedCurrentValueItem1 = "Item 1 - 45000.57"
+            val expectedTitle = "Title"
+            val expectedCurrentValueItem1 = "Item 1 - \$45000.57"
 
             // Act
             setContent {
                 LineChart(
-                    dataSet = multiDataSet,
+                    data = multiDataSet,
+                    title = expectedTitle,
+                    valueFormatter = ChartValueFormatters.prefix("$"),
                     renderMode = LineChartRenderMode.Timeline,
                 )
             }
 
             // Assert
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
             onNodeWithTag(TestTags.CHART_TITLE)
                 .assertTextEquals(expectedTitle)
-                .isDisplayed()
+                .assertIsDisplayed()
             onAllNodesWithText(expectedCurrentValueItem1).assertCountEquals(0)
-            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -77,24 +79,24 @@ class MultiLineChartTest {
     fun multiLineChart_withSelectedPointIndex_displaysSelectedPointDetails() =
         runComposeUiTest {
             val selectedIndex = 2
-            val expectedTitle = multiDataSet.data.categories[selectedIndex]
-            val expectedCurrentValueItem1 =
-                "${multiDataSet.data.items[0].label} - ${multiDataSet.data.items[0]
-                    .item.labels[selectedIndex]}"
-
+            val expectedTitle = multiDataSet.categories[selectedIndex]
             setContent {
                 LineChart(
-                    dataSet = multiDataSet,
+                    data = multiDataSet,
+                    title = "Title",
+                    valueFormatter = ChartValueFormatters.prefix("$"),
                     interactionEnabled = false,
                     animateOnStart = false,
-                    selectedPointIndex = selectedIndex,
+                    selection = staticChartSelection(selectedIndex),
                 )
             }
 
             onNodeWithTag(TestTags.CHART_TITLE)
                 .assertTextEquals(expectedTitle)
-                .isDisplayed()
-            onNodeWithText(expectedCurrentValueItem1).isDisplayed()
+                .assertIsDisplayed()
+            // The selected axis title is the stable public readout contract; legend layout is
+            // rendered by the shared FlowRow and is covered by screenshot/platform tests.
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -105,19 +107,21 @@ class MultiLineChartTest {
             val categories = List(points) { index -> "P${index + 1}" }
             val dataSet =
                 listOf(
-                    "Item 1" to List(points) { index -> (index % 40).toFloat() },
-                    "Item 2" to List(points) { index -> ((index % 40) + 10).toFloat() },
-                ).toMultiChartDataSet(
-                    title = "Dense Multi",
-                    categories = categories,
-                )
+                    ChartSeries(name = "Item 1", values = List(points) { index -> (index % 40).toDouble() }),
+                    ChartSeries(name = "Item 2", values = List(points) { index -> ((index % 40) + 10).toDouble() }),
+                ).let { series ->
+                    chartDataOf(
+                        categories = categories,
+                        *series.toTypedArray(),
+                    )
+                }
 
             setContent {
-                LineChart(dataSet = dataSet)
+                LineChart(data = dataSet, title = "Dense Multi")
             }
 
-            onNodeWithTag(TestTags.LINE_CHART).isDisplayed()
-            onNodeWithTag(TestTags.LINE_CHART_DENSE_EXPAND).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART).assertIsDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_DENSE_EXPAND).assertIsDisplayed()
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_OUT).assertCountEquals(0)
             onAllNodesWithTag(TestTags.LINE_CHART_ZOOM_IN).assertCountEquals(0)
         }
@@ -128,18 +132,18 @@ class MultiLineChartTest {
         runComposeUiTest {
             val dataSet =
                 listOf(
-                    "Item 1" to listOf(10f, 20f, 30f, 40f),
-                    "Item 2" to listOf(5f, 15f, 25f, 35f),
-                ).toMultiChartDataSet(
-                    title = "No Categories",
-                )
+                    ChartSeries(name = "Item 1", values = listOf(10.0, 20.0, 30.0, 40.0)),
+                    ChartSeries(name = "Item 2", values = listOf(5.0, 15.0, 25.0, 35.0)),
+                ).let { series ->
+                    chartDataOf(categories = emptyList(), *series.toTypedArray())
+                }
 
             setContent {
-                LineChart(dataSet = dataSet)
+                LineChart(data = dataSet, title = "No Categories")
             }
 
             onAllNodesWithTag(TestTags.LINE_CHART_X_AXIS_LABELS).assertCountEquals(0)
-            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).isDisplayed()
+            onNodeWithTag(TestTags.LINE_CHART_Y_AXIS_LABELS).assertIsDisplayed()
         }
 
     @OptIn(ExperimentalTestApi::class)
@@ -149,48 +153,23 @@ class MultiLineChartTest {
             // Arrange
             val dataSet = invalidMultiDataSet()
             val colors = colors.drop(1)
-            val firstIndex = 1
-            val thirdIndex = 3
-
-            val pointsSizeFirst =
-                dataSet.data.items[firstIndex]
-                    .item.points.size
-            val pointsSizeThird =
-                dataSet.data.items[thirdIndex]
-                    .item.points.size
-            val expectedPointsSize =
-                dataSet.data.items
-                    .first()
-                    .item.points.size
-
-            val expectedPointsErrorFirst = RULE_ITEM_POINTS_SIZE.format(firstIndex, pointsSizeFirst, expectedPointsSize)
-            val expectedPointsErrorSecond =
-                RULE_ITEM_POINTS_SIZE.format(
-                    thirdIndex,
-                    pointsSizeThird,
-                    expectedPointsSize,
-                )
-
-            val expectedColorsSize = dataSet.data.items.size
-            val colorsSize = colors.size
-            val expectedColorsError = RULE_COLORS_SIZE_MISMATCH.format(colorsSize, expectedColorsSize)
-
             // Act
             setContent {
                 val style =
                     LineChartDefaults.style(
-                        lineColors = colors,
+                        line = LineChartDefaults.line(colors = colors),
                     )
                 LineChart(
-                    dataSet = dataSet,
+                    data = dataSet,
+                    title = "Title",
                     style = style,
                 )
             }
 
             // Assert
-            onNodeWithTag(TestTags.CHART_ERROR).isDisplayed()
-            onNodeWithText("${expectedPointsErrorFirst}\n").isDisplayed()
-            onNodeWithText("${expectedPointsErrorSecond}\n").isDisplayed()
-            onNodeWithText("${expectedColorsError}\n").isDisplayed()
+            onNodeWithTag(TestTags.CHART_ERROR).assertIsDisplayed()
+            onNodeWithText("Category count", substring = true).assertIsDisplayed()
+            onNodeWithText("Series 1 is not aligned", substring = true).assertIsDisplayed()
+            onNodeWithText("Line color count", substring = true).assertIsDisplayed()
         }
 }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
@@ -8,10 +8,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
 import io.github.dautovicharis.charts.internal.common.model.ChartDataType.FloatData
+import io.github.dautovicharis.charts.internal.linechart.LineChartInternalStyle
 import io.github.dautovicharis.charts.model.ChartDataSet
 import io.github.dautovicharis.charts.model.MultiChartDataSet
 import io.github.dautovicharis.charts.style.ChartContainerStyle
-import io.github.dautovicharis.charts.style.LineChartStyle
 import io.github.dautovicharis.charts.style.RadarChartStyle
 import io.github.dautovicharis.charts.style.StackedAreaChartStyle
 import io.github.dautovicharis.charts.style.StackedBarChartStyle
@@ -110,22 +110,24 @@ internal object MockTest {
         )
 
     // Mock styles
-    fun mockLineChartStyle(lineColors: List<Color> = colors): LineChartStyle =
-        LineChartStyle(
+    fun mockLineChartStyle(lineColors: List<Color> = colors): LineChartInternalStyle =
+        LineChartInternalStyle(
             modifier = Modifier.fillMaxSize(),
+            chartContainerStyle = mockChartContainerStyle(),
+            dragPointColorSameAsLine = true,
+            pointColorSameAsLine = true,
             pointColor = Color.Red,
-            pointSize = 10f,
             pointVisible = true,
+            pointSize = 10f,
             lineColor = Color.Green,
             lineAlpha = 1f,
             lineColors = lineColors,
             bezier = true,
+            lineStrokeWidth = 1f,
             dragPointSize = 7f,
             dragPointVisible = true,
             dragActivePointSize = 12f,
             dragPointColor = Color.Red,
-            dragPointColorSameAsLine = true,
-            pointColorSameAsLine = true,
             axisVisible = true,
             axisColor = Color.Gray,
             axisLineWidth = 1f,
@@ -138,7 +140,6 @@ internal object MockTest {
             xAxisLabelSize = 11.sp,
             xAxisLabelMaxCount = 6,
             zoomControlsVisible = true,
-            chartContainerStyle = mockChartContainerStyle(),
         )
 
     fun mockStackedBarChartStyle(barColors: List<Color> = colors): StackedBarChartStyle =

--- a/release-notes/3.0.0/changes/line-v3.md
+++ b/release-notes/3.0.0/changes/line-v3.md
@@ -1,0 +1,5 @@
+# PR Changeset
+
+- type: `feat`
+- module: `charts-line`
+- release_note: `Migrated single-line and multi-line charts to one Compose-friendly LineChart API backed by shared ChartData, hoisted ChartSelection, grouped line styles, Double values, explicit categories, and separate value/axis formatters. Legacy ChartDataSet and MultiChartDataSet line entry points and selectedPointIndex are removed.`

--- a/release-notes/3.0.0/migrations/line-v3.md
+++ b/release-notes/3.0.0/migrations/line-v3.md
@@ -1,0 +1,52 @@
+# Single and Multi-Line v3 migration
+
+This part migrates the line family to the shared v3 API. One `LineChart` composable handles one or more aligned `ChartSeries`; there is no separate `MultiLineChart` alias.
+
+## Public API
+
+```kotlin
+val selection = rememberChartSelection()
+
+LineChart(
+    data = chartData,
+    modifier = Modifier.fillMaxWidth(),
+    style = LineChartDefaults.style(),
+    title = "Temperature",
+    selection = selection,
+    renderMode = LineChartRenderMode.Morph,
+    valueFormatter = LineChartDefaults.valueFormatter,
+    axisValueFormatter = LineChartDefaults.axisValueFormatter,
+)
+```
+
+`chartData` is shared `ChartData` with `List<Double>` values. Use `List<Double>.toChartData(categories = ..., seriesName = ...)` for one series or `chartDataOf(categories = ..., ChartSeries(...), ...)` for multiple series. Categories are explicit labels, not numeric X coordinates; empty categories hide the X-label layer and do not create index-string labels.
+
+The old `LineChart(dataSet: ChartDataSet, ...)` and `LineChart(dataSet: MultiChartDataSet, ...)` entry points are removed. `selectedPointIndex` is removed; use `selection = staticChartSelection(index)` for screenshots and deterministic previews. Selection is a source X index shared by every line. Replacing data clears selection, while resize, scrolling, compact/expanded changes, and external callback replacement preserve the current source selection where it remains valid.
+
+## Grouped style
+
+`LineChartStyle` is now grouped into:
+
+- `line: LineVisualStyle` — color, alpha, per-series colors, stroke width (`Dp`), and Bezier interpolation.
+- `points: LinePointStyle` — color, size (`Dp`), and visibility.
+- `selection: LineSelectionStyle` — drag color, normal/active sizes (`Dp`), and visibility.
+- `axis: LineAxisStyle` — visibility/color/width plus `xLabels` and `yLabels` `AxisLabelStyle` blocks.
+- `chartContainerStyle` and `zoomControlsVisible`.
+
+Defaults are available through `LineChartDefaults.style`, `line`, `points`, `selection`, `axis`, `xLabels`, and `yLabels`. Physical widths and marker sizes are density-aware. The line renderer temporarily adapts the grouped style to a flat internal renderer shape; that internal adapter is not a public v2 compatibility API and may be removed in a later renderer cleanup.
+
+## Formatting and selection
+
+`valueFormatter` formats selected raw values. `axisValueFormatter` independently formats Y-axis ticks. Both receive `Double`, default to the shared formatter contract, and avoid JVM-only formatting. Multi-line selection resolves one source index across all series; the selected title uses the category when categories exist, and the selected series values remain separate legend/readout values.
+
+Morph continues to support compact averaging for dense data, but source-index mapping selects a bucket-center source point and readouts are taken from source data. Expanded/scrollable rendering uses the same source mapping. Timeline retains its update animation semantics and uses one domain for animated geometry and ticks.
+
+Malformed data is rejected before internal conversion: empty data, fewer than two points, ragged series, category mismatch, non-finite values, and invalid palette/line dimensions render the existing error UI with the caller modifier. Interaction-disabled charts do not accept user gestures or control changes; programmatic selection still renders.
+
+## Sample and test migration
+
+Line samples, previews, screenshot call sites, GIF scenarios, the smoke consumer, UI tests, dense-data tests, and shared validation fixtures now construct `ChartData`/`ChartSeries` explicitly. Legacy dataset models remain in `charts-core` because Radar, Stacked Bar, and Stacked Area still consume them; they are deleted only after their last consumer migrates.
+
+## Validation
+
+The local line JVM suite, line production/test compilation, Wasm test-source compilation, smoke-line compilation, sample compilation, and lint are the implementation gates for this part. Android screenshot, browser execution, emulator, simulator, and API compatibility checks remain CI gates and are not claimed as locally run by this migration note.

--- a/sample/androidApp/src/main/kotlin/dev/hdcode/charts/app/gif/DocsGifScenarios.kt
+++ b/sample/androidApp/src/main/kotlin/dev/hdcode/charts/app/gif/DocsGifScenarios.kt
@@ -25,6 +25,7 @@ import io.github.dautovicharis.charts.PieChart
 import io.github.dautovicharis.charts.RadarChart
 import io.github.dautovicharis.charts.StackedAreaChart
 import io.github.dautovicharis.charts.StackedBarChart
+import io.github.dautovicharis.charts.model.ChartValueFormatters
 import io.github.hdcodedev.composegif.annotations.GifFractionPoint
 import io.github.hdcodedev.composegif.annotations.GifGestureStep
 import io.github.hdcodedev.composegif.annotations.GifGestureType
@@ -71,7 +72,7 @@ fun PieDefaultGifScenario() {
 @Composable
 fun LineDefaultGifScenario() {
     DocsGifScene {
-        LineChart(lineSampleUseCase().initialLineDataSet())
+        LineChart(data = lineSampleUseCase().initialLineDataSet())
     }
 }
 
@@ -93,7 +94,8 @@ fun LineDefaultGifScenario() {
 @Composable
 fun MultiLineDefaultGifScenario() {
     DocsGifScene {
-        LineChart(multiLineSampleUseCase().initialMultiLineSample().dataSet)
+        val sample = multiLineSampleUseCase().initialMultiLineSample()
+        LineChart(data = sample.dataSet, title = sample.title, valueFormatter = ChartValueFormatters.prefix("$"))
     }
 }
 

--- a/sample/androidApp/src/screenshotTest/kotlin/dev/hdcode/charts/app/screenshot/LineChartScreenshotTest.kt
+++ b/sample/androidApp/src/screenshotTest/kotlin/dev/hdcode/charts/app/screenshot/LineChartScreenshotTest.kt
@@ -9,19 +9,27 @@ import dev.hdcode.charts.app.screenshot.shared.ScreenshotPreview
 import dev.hdcode.charts.app.screenshot.shared.ScreenshotSurface
 import dev.hdcode.charts.sampleshared.fixtures.ChartTestStyleFixtures
 import io.github.dautovicharis.charts.LineChart
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.ChartValueFormatters
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.staticChartSelection
 import io.github.dautovicharis.charts.style.ChartContainerDefaults
 
 private const val MULTI_LINE_SELECTION_INDEX = 4
 
-private val MULTI_LINE_SELECTION_DATA_SET =
-    listOf(
-        "P50 Latency" to listOf(122.5, 149.125, 134.333, 126.75, 101.322397132296, 114.667, 129.75),
-        "P95 Latency" to listOf(167.75, 219.2, 176.85, 161.45, 151.31476088115193, 166.42, 188.95),
-    ).toMultiChartDataSet(
-        title = "14:00:28",
+private val MULTI_LINE_SELECTION_DATA =
+    chartDataOf(
         categories = listOf("14:00:00", "14:00:07", "14:00:14", "14:00:21", "14:00:28", "14:00:35", "14:00:42"),
-        postfix = " ms",
+        *arrayOf(
+            ChartSeries(
+                name = "P50 Latency",
+                values = listOf(122.5, 149.125, 134.333, 126.75, 101.322397132296, 114.667, 129.75),
+            ),
+            ChartSeries(
+                name = "P95 Latency",
+                values = listOf(167.75, 219.2, 176.85, 161.45, 151.31476088115193, 166.42, 188.95),
+            ),
+        ),
     )
 
 @PreviewTest
@@ -30,7 +38,7 @@ private val MULTI_LINE_SELECTION_DATA_SET =
 fun LineChartDefaultPreview() {
     ScreenshotSurface {
         LineChart(
-            dataSet = SCREENSHOT_LINE_SAMPLE_USE_CASE.initialLineDataSet(),
+            data = SCREENSHOT_LINE_SAMPLE_USE_CASE.initialLineDataSet(),
             animateOnStart = SCREENSHOT_ANIMATE_ON_START,
         )
     }
@@ -42,7 +50,7 @@ fun LineChartDefaultPreview() {
 fun LineChartCustomPreview() {
     ScreenshotSurface {
         LineChart(
-            dataSet = SCREENSHOT_LINE_SAMPLE_USE_CASE.initialLineDataSet(),
+            data = SCREENSHOT_LINE_SAMPLE_USE_CASE.initialLineDataSet(),
             style = ChartTestStyleFixtures.lineCustomStyle(chartContainerStyle = ChartContainerDefaults.style()),
             animateOnStart = SCREENSHOT_ANIMATE_ON_START,
         )
@@ -55,7 +63,9 @@ fun LineChartCustomPreview() {
 fun MultiLineChartDefaultPreview() {
     ScreenshotSurface {
         LineChart(
-            dataSet = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().dataSet,
+            data = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().dataSet,
+            title = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().title,
+            valueFormatter = ChartValueFormatters.prefix("$"),
             animateOnStart = SCREENSHOT_ANIMATE_ON_START,
         )
     }
@@ -67,7 +77,9 @@ fun MultiLineChartDefaultPreview() {
 fun MultiLineChartCustomPreview() {
     ScreenshotSurface {
         LineChart(
-            dataSet = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().dataSet,
+            data = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().dataSet,
+            title = SCREENSHOT_MULTI_LINE_SAMPLE_USE_CASE.initialMultiLineSample().title,
+            valueFormatter = ChartValueFormatters.prefix("$"),
             style =
                 ChartTestStyleFixtures.multiLineCustomStyle(
                     chartContainerStyle = ChartContainerDefaults.style(),
@@ -84,15 +96,17 @@ fun MultiLineChartCustomPreview() {
 fun MultiLineChartSelectionLegendPreview() {
     ScreenshotSurface {
         LineChart(
-            dataSet = MULTI_LINE_SELECTION_DATA_SET,
+            data = MULTI_LINE_SELECTION_DATA,
+            title = "14:00:28",
+            valueFormatter = ChartValueFormatters.suffix(" ms"),
             style =
                 ChartTestStyleFixtures.multiLineCustomStyle(
                     chartContainerStyle = ChartContainerDefaults.style(),
-                    seriesCount = MULTI_LINE_SELECTION_DATA_SET.data.items.size,
+                    seriesCount = MULTI_LINE_SELECTION_DATA.series.size,
                 ),
             interactionEnabled = false,
             animateOnStart = SCREENSHOT_ANIMATE_ON_START,
-            selectedPointIndex = MULTI_LINE_SELECTION_INDEX,
+            selection = staticChartSelection(MULTI_LINE_SELECTION_INDEX),
         )
     }
 }

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/ChartGalleryPreviews.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/ChartGalleryPreviews.kt
@@ -23,9 +23,10 @@ import io.github.dautovicharis.charts.PieChart
 import io.github.dautovicharis.charts.RadarChart
 import io.github.dautovicharis.charts.StackedAreaChart
 import io.github.dautovicharis.charts.StackedBarChart
+import io.github.dautovicharis.charts.model.ChartSeries
 import io.github.dautovicharis.charts.model.PieSlice
+import io.github.dautovicharis.charts.model.chartDataOf
 import io.github.dautovicharis.charts.model.toChartData
-import io.github.dautovicharis.charts.model.toChartDataSet
 import io.github.dautovicharis.charts.model.toMultiChartDataSet
 import io.github.dautovicharis.charts.style.BarChartDefaults
 import io.github.dautovicharis.charts.style.ChartContainerDefaults
@@ -113,17 +114,20 @@ private fun PieChartPreview(values: List<Float>) {
 
 @Composable
 private fun LineChartPreview(values: List<Float>) {
-    val dataSet =
+    val data =
         remember(values) {
-            values.toChartDataSet(title = "")
+            values.map { it.toDouble() }.toChartData(seriesName = "")
         }
     LineChart(
-        dataSet = dataSet,
+        data = data,
         style =
             LineChartDefaults.style(
                 chartContainerStyle = previewChartContainerStyle(),
-                xAxisLabelsVisible = false,
-                yAxisLabelsVisible = false,
+                axis =
+                    LineChartDefaults.axis(
+                        xLabels = LineChartDefaults.xLabels(visible = false),
+                        yLabels = LineChartDefaults.yLabels(visible = false),
+                    ),
             ),
         interactionEnabled = false,
         animateOnStart = true,
@@ -132,17 +136,26 @@ private fun LineChartPreview(values: List<Float>) {
 
 @Composable
 private fun MultiLineChartPreview(series: List<Pair<String, List<Float>>>) {
-    val dataSet =
+    val data =
         remember(series) {
-            series.toMultiChartDataSet(title = "")
+            chartDataOf(
+                categories = emptyList(),
+                *series
+                    .map { (name, values) ->
+                        ChartSeries(name = name, values = values.map { it.toDouble() })
+                    }.toTypedArray(),
+            )
         }
     LineChart(
-        dataSet = dataSet,
+        data = data,
         style =
             LineChartDefaults.style(
                 chartContainerStyle = previewChartContainerStyle(),
-                xAxisLabelsVisible = false,
-                yAxisLabelsVisible = false,
+                axis =
+                    LineChartDefaults.axis(
+                        xLabels = LineChartDefaults.xLabels(visible = false),
+                        yLabels = LineChartDefaults.yLabels(visible = false),
+                    ),
             ),
         interactionEnabled = false,
         animateOnStart = true,

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/data/LiveLatencyTimelineUseCase.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/data/LiveLatencyTimelineUseCase.kt
@@ -1,7 +1,6 @@
 package dev.hdcode.charts.app.data
 
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.MultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
 
 data class LiveLatencySingleSeriesWindow(
     val values: List<Float>,
@@ -26,7 +25,7 @@ interface LiveLatencyTimelineUseCase {
 
     fun advanceSingleWindow(window: LiveLatencySingleSeriesWindow): LiveLatencySingleSeriesWindow
 
-    fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartDataSet
+    fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartData
 
     fun createMultiWindow(
         windowSize: Int,
@@ -35,5 +34,5 @@ interface LiveLatencyTimelineUseCase {
 
     fun advanceMultiWindow(window: LiveLatencyMultiSeriesWindow): LiveLatencyMultiSeriesWindow
 
-    fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): MultiChartDataSet
+    fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): ChartData
 }

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/data/impl/DefaultLiveLatencyTimelineUseCase.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/data/impl/DefaultLiveLatencyTimelineUseCase.kt
@@ -3,10 +3,10 @@ package dev.hdcode.charts.app.data.impl
 import dev.hdcode.charts.app.data.LiveLatencyMultiSeriesWindow
 import dev.hdcode.charts.app.data.LiveLatencySingleSeriesWindow
 import dev.hdcode.charts.app.data.LiveLatencyTimelineUseCase
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.MultiChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.chartDataOf
+import io.github.dautovicharis.charts.model.toChartData
 import kotlin.math.sin
 import kotlin.random.Random
 
@@ -23,8 +23,7 @@ class DefaultLiveLatencyTimelineUseCase : LiveLatencyTimelineUseCase {
     override fun advanceSingleWindow(window: LiveLatencySingleSeriesWindow): LiveLatencySingleSeriesWindow =
         generator.advanceSingleWindow(window)
 
-    override fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartDataSet =
-        generator.toSingleDataSet(window)
+    override fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartData = generator.toSingleDataSet(window)
 
     override fun createMultiWindow(
         windowSize: Int,
@@ -34,8 +33,7 @@ class DefaultLiveLatencyTimelineUseCase : LiveLatencyTimelineUseCase {
     override fun advanceMultiWindow(window: LiveLatencyMultiSeriesWindow): LiveLatencyMultiSeriesWindow =
         generator.advanceMultiWindow(window)
 
-    override fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): MultiChartDataSet =
-        generator.toMultiDataSet(window)
+    override fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): ChartData = generator.toMultiDataSet(window)
 }
 
 private class LiveLatencyTimelineGenerator {
@@ -44,10 +42,8 @@ private class LiveLatencyTimelineGenerator {
         private const val SECONDS_PER_DAY = 24 * 60 * 60
         private const val BASE_SECOND_OF_DAY = 14 * 60 * 60
         private const val SINGLE_TITLE = "API Gateway P95 Latency"
-        private const val MULTI_TITLE = "API Latency (P50 vs P95)"
         private const val P50_SERIES_LABEL = "P50 Latency"
         private const val P95_SERIES_LABEL = "P95 Latency"
-        private const val VALUE_POSTFIX = " ms"
     }
 
     val multiSeriesKeys: List<String> = listOf(P50_SERIES_LABEL, P95_SERIES_LABEL)
@@ -83,11 +79,10 @@ private class LiveLatencyTimelineGenerator {
         )
     }
 
-    fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartDataSet =
-        window.values.toChartDataSet(
-            title = SINGLE_TITLE,
-            labels = window.labels,
-        )
+    fun toSingleDataSet(window: LiveLatencySingleSeriesWindow): ChartData =
+        window.values
+            .map { it.toDouble() }
+            .toChartData(categories = window.labels, seriesName = SINGLE_TITLE)
 
     fun createMultiWindow(
         windowSize: Int,
@@ -126,14 +121,13 @@ private class LiveLatencyTimelineGenerator {
         )
     }
 
-    fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): MultiChartDataSet =
-        listOf(
-            P50_SERIES_LABEL to window.p50Values,
-            P95_SERIES_LABEL to window.p95Values,
-        ).toMultiChartDataSet(
-            title = MULTI_TITLE,
+    fun toMultiDataSet(window: LiveLatencyMultiSeriesWindow): ChartData =
+        chartDataOf(
             categories = window.labels,
-            postfix = VALUE_POSTFIX,
+            *arrayOf(
+                ChartSeries(name = P50_SERIES_LABEL, values = window.p50Values.map { it.toDouble() }),
+                ChartSeries(name = P95_SERIES_LABEL, values = window.p95Values.map { it.toDouble() }),
+            ),
         )
 
     private fun resolveEndTick(

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/line/LineChartViewModel.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/line/LineChartViewModel.kt
@@ -6,8 +6,8 @@ import dev.hdcode.charts.app.data.LiveLatencySingleSeriesWindow
 import dev.hdcode.charts.app.data.LiveLatencyTimelineUseCase
 import dev.hdcode.charts.app.demo.timeline.LiveTimelineControlsState
 import dev.hdcode.charts.app.demo.timeline.LiveTimelineDefaults
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.toChartData
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,7 +30,7 @@ enum class LineDemoPreset {
 }
 
 data class LineChartUiState(
-    val dataSet: ChartDataSet,
+    val dataSet: ChartData,
     val dataControlsState: LineChartDataControlsState,
     val timelineControlsState: LiveTimelineControlsState,
     val preset: LineDemoPreset = LineDemoPreset.Default,
@@ -262,17 +262,15 @@ class LineChartViewModel(
         liveUpdatesJob = null
     }
 
-    private fun buildGeneratedDataSet(controls: LineChartDataControlsState): ChartDataSet {
+    private fun buildGeneratedDataSet(controls: LineChartDataControlsState): ChartData {
         val baseWindow =
             liveLatencyTimelineUseCase.createSingleWindow(
                 windowSize = controls.points,
                 endTick = timelineWindow.endTick,
             )
         val baseDataSet = liveLatencyTimelineUseCase.toSingleDataSet(baseWindow)
-        val basePoints = baseDataSet.data.item.points
-        val labels =
-            baseDataSet.data.item.labels
-                .toList()
+        val basePoints = baseDataSet.series.first().values
+        val labels = baseDataSet.categories.toList()
         val safeMin = controls.minValue.toDouble()
         val safeMax = controls.maxValue.toDouble().coerceAtLeast(safeMin + 1.0)
         val sourceMin = basePoints.minOrNull() ?: 0.0
@@ -281,17 +279,14 @@ class LineChartViewModel(
 
         val normalizedValues =
             if (sourceRange == 0.0) {
-                List(basePoints.size) { safeMin.toFloat() }
+                List(basePoints.size) { safeMin }
             } else {
                 basePoints.map { point ->
                     val normalized = ((point - sourceMin) / sourceRange).coerceIn(0.0, 1.0)
-                    (safeMin + normalized * (safeMax - safeMin)).toFloat()
+                    safeMin + normalized * (safeMax - safeMin)
                 }
             }
 
-        return normalizedValues.toChartDataSet(
-            title = baseDataSet.data.label,
-            labels = labels,
-        )
+        return normalizedValues.toChartData(categories = labels, seriesName = baseDataSet.series.first().name)
     }
 }

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/line/LineDemo.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/line/LineDemo.kt
@@ -122,14 +122,14 @@ fun LineChartDemo(viewModel: LineChartViewModel = koinViewModel()) {
         when (uiState.preset) {
             LineDemoPreset.Default -> {
                 LineChart(
-                    dataSet = uiState.dataSet,
+                    data = uiState.dataSet,
                     style = LineChartDefaults.style(chartContainerStyle = chartContainerStyle),
                 )
             }
 
             LineDemoPreset.Timeline -> {
                 LineChart(
-                    dataSet = uiState.dataSet,
+                    data = uiState.dataSet,
                     style = LineChartDefaults.style(chartContainerStyle = chartContainerStyle),
                     renderMode = LineChartRenderMode.Timeline,
                     animationDurationMillis = timelineAnimationDuration,
@@ -138,7 +138,7 @@ fun LineChartDemo(viewModel: LineChartViewModel = koinViewModel()) {
 
             LineDemoPreset.Custom -> {
                 LineChart(
-                    dataSet = uiState.dataSet,
+                    data = uiState.dataSet,
                     style = ChartTestStyleFixtures.lineCustomStyle(chartContainerStyle = chartContainerStyle),
                 )
             }

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/multiline/MultiLineChartViewModel.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/multiline/MultiLineChartViewModel.kt
@@ -6,8 +6,9 @@ import dev.hdcode.charts.app.data.LiveLatencyMultiSeriesWindow
 import dev.hdcode.charts.app.data.LiveLatencyTimelineUseCase
 import dev.hdcode.charts.app.demo.timeline.LiveTimelineControlsState
 import dev.hdcode.charts.app.demo.timeline.LiveTimelineDefaults
-import io.github.dautovicharis.charts.model.MultiChartDataSet
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.chartDataOf
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,8 +19,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 data class MultiLineChartState(
-    val dataSet: MultiChartDataSet,
+    val dataSet: ChartData,
     val seriesKeys: List<String> = emptyList(),
+    val title: String,
 )
 
 data class MultiLineChartDataControlsState(
@@ -52,7 +54,7 @@ class MultiLineChartViewModel(
         const val MAX_SUPPORTED_VALUE = 400
         private const val DEFAULT_MIN_VALUE = 90
         private const val DEFAULT_MAX_VALUE = 220
-        private const val VALUE_POSTFIX = " ms"
+        private const val CHART_TITLE = "API Latency (P50 vs P95)"
     }
 
     private val initialControlsState = LiveTimelineControlsState()
@@ -239,6 +241,7 @@ class MultiLineChartViewModel(
         MultiLineChartState(
             dataSet = liveLatencyTimelineUseCase.toMultiDataSet(window),
             seriesKeys = liveLatencyTimelineUseCase.multiSeriesKeys,
+            title = CHART_TITLE,
         )
 
     private fun setPlaying(playing: Boolean) {
@@ -285,7 +288,6 @@ class MultiLineChartViewModel(
                 windowSize = controls.points,
                 endTick = timelineWindow.endTick,
             )
-        val baseDataSet = liveLatencyTimelineUseCase.toMultiDataSet(baseWindow)
         val labels = baseWindow.labels.toList()
         val safeMin = controls.minValue.toDouble()
         val safeMax = controls.maxValue.toDouble().coerceAtLeast(safeMin + 1.0)
@@ -308,18 +310,22 @@ class MultiLineChartViewModel(
         val p95Values = normalize(baseWindow.p95Values)
         val seriesKeys = liveLatencyTimelineUseCase.multiSeriesKeys
         val multiDataSet =
-            listOf(
-                seriesKeys.getOrElse(0) { "P50 Latency" } to p50Values,
-                seriesKeys.getOrElse(1) { "P95 Latency" } to p95Values,
-            ).toMultiChartDataSet(
-                title = baseDataSet.data.title,
+            chartDataOf(
                 categories = labels,
-                postfix = VALUE_POSTFIX,
+                ChartSeries(
+                    name = seriesKeys.getOrElse(0) { "P50 Latency" },
+                    values = p50Values.map { it.toDouble() },
+                ),
+                ChartSeries(
+                    name = seriesKeys.getOrElse(1) { "P95 Latency" },
+                    values = p95Values.map { it.toDouble() },
+                ),
             )
 
         return MultiLineChartState(
             dataSet = multiDataSet,
             seriesKeys = seriesKeys,
+            title = CHART_TITLE,
         )
     }
 }

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/multiline/MultiLineDemo.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/demo/multiline/MultiLineDemo.kt
@@ -51,6 +51,7 @@ import dev.hdcode.charts.sampleshared.theme.LocalChartColors
 import dev.hdcode.charts.sampleshared.theme.seriesColors
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.LineChartRenderMode
+import io.github.dautovicharis.charts.model.ChartValueFormatters
 import io.github.dautovicharis.charts.style.ChartContainerDefaults
 import io.github.dautovicharis.charts.style.LineChartDefaults
 import org.jetbrains.compose.resources.stringResource
@@ -126,14 +127,18 @@ fun MultiLineChartDemo(viewModel: MultiLineChartViewModel = koinViewModel()) {
         when (uiState.preset) {
             MultiLineDemoPreset.Default -> {
                 LineChart(
-                    dataSet = uiState.dataSet.dataSet,
+                    data = uiState.dataSet.dataSet,
+                    title = uiState.dataSet.title,
+                    valueFormatter = ChartValueFormatters.suffix(" ms"),
                     style = LineChartDefaults.style(chartContainerStyle = chartContainerStyle),
                 )
             }
 
             MultiLineDemoPreset.Timeline -> {
                 LineChart(
-                    dataSet = uiState.dataSet.dataSet,
+                    data = uiState.dataSet.dataSet,
+                    title = uiState.dataSet.title,
+                    valueFormatter = ChartValueFormatters.suffix(" ms"),
                     style = LineChartDefaults.style(chartContainerStyle = chartContainerStyle),
                     renderMode = LineChartRenderMode.Timeline,
                     animationDurationMillis = timelineAnimationDuration,
@@ -147,7 +152,9 @@ fun MultiLineChartDemo(viewModel: MultiLineChartViewModel = koinViewModel()) {
                         seriesCount = lineColors.size,
                     )
                 LineChart(
-                    dataSet = uiState.dataSet.dataSet,
+                    data = uiState.dataSet.dataSet,
+                    title = uiState.dataSet.title,
+                    valueFormatter = ChartValueFormatters.suffix(" ms"),
                     style = customStyle,
                 )
             }

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/BasicChartSampleUseCases.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/BasicChartSampleUseCases.kt
@@ -1,7 +1,6 @@
 package dev.hdcode.charts.sampleshared.data
 
 import io.github.dautovicharis.charts.model.ChartData
-import io.github.dautovicharis.charts.model.ChartDataSet
 
 interface PieSampleUseCase {
     fun initialPieSample(): PieSampleData
@@ -19,7 +18,7 @@ interface PieSampleUseCase {
 }
 
 interface LineSampleUseCase {
-    fun initialLineDataSet(): ChartDataSet
+    fun initialLineDataSet(): ChartData
 
     fun lineRefreshRange(): IntRange
 
@@ -28,7 +27,7 @@ interface LineSampleUseCase {
     fun lineDataSet(
         range: IntRange,
         numOfPoints: IntRange,
-    ): ChartDataSet
+    ): ChartData
 }
 
 interface BarSampleUseCase {

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/ChartSampleDataModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/ChartSampleDataModels.kt
@@ -1,5 +1,6 @@
 package dev.hdcode.charts.sampleshared.data
 
+import io.github.dautovicharis.charts.model.ChartData
 import io.github.dautovicharis.charts.model.MultiChartDataSet
 import io.github.dautovicharis.charts.model.PieSlice
 
@@ -9,8 +10,9 @@ data class PieSampleData(
 )
 
 data class MultiLineSampleData(
-    val dataSet: MultiChartDataSet,
+    val dataSet: ChartData,
     val seriesKeys: List<String>,
+    val title: String,
 )
 
 data class StackedBarSampleData(

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultLineSampleUseCase.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultLineSampleUseCase.kt
@@ -1,8 +1,8 @@
 package dev.hdcode.charts.sampleshared.data.impl
 
 import dev.hdcode.charts.sampleshared.data.LineSampleUseCase
-import io.github.dautovicharis.charts.model.ChartDataSet
-import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.model.ChartData
+import io.github.dautovicharis.charts.model.toChartData
 
 internal class DefaultLineSampleUseCase : LineSampleUseCase {
     companion object {
@@ -13,11 +13,10 @@ internal class DefaultLineSampleUseCase : LineSampleUseCase {
     private val defaultValues = listOf(42f, 38f, 45f, 51f, 47f, 54f, 49f)
     private val defaultLabels = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
-    override fun initialLineDataSet(): ChartDataSet =
-        defaultValues.toChartDataSet(
-            title = DEFAULT_TITLE,
-            labels = defaultLabels,
-        )
+    override fun initialLineDataSet(): ChartData =
+        defaultValues
+            .map { it.toDouble() }
+            .toChartData(categories = defaultLabels, seriesName = DEFAULT_TITLE)
 
     override fun lineRefreshRange(): IntRange = REFRESH_RANGE
 
@@ -26,13 +25,12 @@ internal class DefaultLineSampleUseCase : LineSampleUseCase {
     override fun lineDataSet(
         range: IntRange,
         numOfPoints: IntRange,
-    ): ChartDataSet {
+    ): ChartData {
         val points = numOfPoints.random()
         val values = List(points) { range.random() }
-        return values.toChartDataSet(
-            title = DEFAULT_TITLE,
-            labels = labelsForPoints(points),
-        )
+        return values
+            .map { it.toDouble() }
+            .toChartData(categories = labelsForPoints(points), seriesName = DEFAULT_TITLE)
     }
 
     private fun labelsForPoints(points: Int): List<String> {

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultMultiLineSampleUseCase.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultMultiLineSampleUseCase.kt
@@ -2,12 +2,12 @@ package dev.hdcode.charts.sampleshared.data.impl
 
 import dev.hdcode.charts.sampleshared.data.MultiLineSampleData
 import dev.hdcode.charts.sampleshared.data.MultiLineSampleUseCase
-import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import io.github.dautovicharis.charts.model.ChartSeries
+import io.github.dautovicharis.charts.model.chartDataOf
 
 internal class DefaultMultiLineSampleUseCase : MultiLineSampleUseCase {
     companion object {
         private const val DEFAULT_TITLE = "Weekly Revenue by Channel"
-        private const val DEFAULT_PREFIX = "$"
         private val REFRESH_RANGE = 100..1000
     }
 
@@ -23,12 +23,15 @@ internal class DefaultMultiLineSampleUseCase : MultiLineSampleUseCase {
     override fun initialMultiLineSample(): MultiLineSampleData =
         MultiLineSampleData(
             dataSet =
-                multiLineItems.toMultiChartDataSet(
-                    title = DEFAULT_TITLE,
-                    prefix = DEFAULT_PREFIX,
+                chartDataOf(
                     categories = multiLineCategories,
+                    *multiLineItems
+                        .map { (name, values) ->
+                            ChartSeries(name = name, values = values.map { it.toDouble() })
+                        }.toTypedArray(),
                 ),
             seriesKeys = multiLineItems.map { it.first },
+            title = DEFAULT_TITLE,
         )
 
     override fun multiLineRefreshRange(): IntRange = REFRESH_RANGE
@@ -39,14 +42,17 @@ internal class DefaultMultiLineSampleUseCase : MultiLineSampleUseCase {
                 name to values.map { range.random().toFloat() }
             }
         val dataSet =
-            newItems.toMultiChartDataSet(
-                prefix = DEFAULT_PREFIX,
+            chartDataOf(
                 categories = multiLineCategories,
-                title = DEFAULT_TITLE,
+                *newItems
+                    .map { (name, values) ->
+                        ChartSeries(name = name, values = values.map { it.toDouble() })
+                    }.toTypedArray(),
             )
         return MultiLineSampleData(
             dataSet = dataSet,
             seriesKeys = newItems.map { it.first },
+            title = DEFAULT_TITLE,
         )
     }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/fixtures/ChartTestStyleFixtures.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/fixtures/ChartTestStyleFixtures.kt
@@ -23,6 +23,7 @@ import io.github.dautovicharis.charts.style.StackedAreaChartDefaults
 import io.github.dautovicharis.charts.style.StackedAreaChartStyle
 import io.github.dautovicharis.charts.style.StackedBarChartDefaults
 import io.github.dautovicharis.charts.style.StackedBarChartStyle
+import io.github.dautovicharis.charts.style.defaultChartAlpha as chartDefaultAlpha
 
 /**
  * Shared custom style fixtures used by:
@@ -62,14 +63,20 @@ object ChartTestStyleFixtures {
         val chartColors = LocalChartColors.current
         return LineChartDefaults.style(
             chartContainerStyle = chartContainerStyle,
-            lineColor = chartColors.seriesColor(1),
-            pointSize = 9f,
-            bezier = false,
-            dragPointVisible = true,
-            pointVisible = true,
-            dragPointColor = chartColors.selection,
-            dragPointSize = 8f,
-            dragActivePointSize = 10f,
+            line = LineChartDefaults.line(color = chartColors.seriesColor(1), bezier = false),
+            points =
+                LineChartDefaults.points(
+                    color = chartColors.seriesColor(1).copy(alpha = chartDefaultAlpha()),
+                    size = 9.dp,
+                    visible = true,
+                ),
+            selection =
+                LineChartDefaults.selection(
+                    color = chartColors.selection,
+                    size = 8.dp,
+                    activeSize = 10.dp,
+                    visible = true,
+                ),
         )
     }
 
@@ -81,12 +88,17 @@ object ChartTestStyleFixtures {
         val chartColors = LocalChartColors.current
         return LineChartDefaults.style(
             chartContainerStyle = chartContainerStyle,
-            lineColors = chartColors.seriesColors(seriesCount),
-            bezier = false,
-            pointVisible = true,
-            dragPointVisible = false,
-            pointColor = chartColors.highlight,
-            dragPointColor = chartColors.selection,
+            line = LineChartDefaults.line(colors = chartColors.seriesColors(seriesCount), bezier = false),
+            points =
+                LineChartDefaults.points(
+                    color = chartColors.highlight,
+                    visible = true,
+                ),
+            selection =
+                LineChartDefaults.selection(
+                    color = chartColors.selection,
+                    visible = false,
+                ),
         )
     }
 

--- a/smoke-line/src/commonMain/kotlin/io/github/dautovicharis/charts/smoke/LineOnlySmoke.kt
+++ b/smoke-line/src/commonMain/kotlin/io/github/dautovicharis/charts/smoke/LineOnlySmoke.kt
@@ -2,18 +2,18 @@ package io.github.dautovicharis.charts.smoke
 
 import androidx.compose.runtime.Composable
 import io.github.dautovicharis.charts.LineChart
-import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.model.toChartData
 
 val lineOnlySmokeDataSet =
-    listOf(10f, 20f, 15f).toChartDataSet(
-        labels = listOf("A", "B", "C"),
-        title = "Smoke",
+    listOf(10.0, 20.0, 15.0).toChartData(
+        categories = listOf("A", "B", "C"),
+        seriesName = "Smoke",
     )
 
 @Composable
 fun LineOnlySmokeChart() {
     LineChart(
-        dataSet = lineOnlySmokeDataSet,
+        data = lineOnlySmokeDataSet,
         interactionEnabled = false,
         animateOnStart = false,
     )


### PR DESCRIPTION
## Summary

Migrates the single-line and multi-line chart family to the shared v3 Compose API. One `LineChart` composable now handles one or more aligned `ChartSeries` values through shared `ChartData`.

## Public API changes

- Replace legacy `LineChart(dataSet: ChartDataSet, ...)` and `LineChart(dataSet: MultiChartDataSet, ...)` with `LineChart(data: ChartData, ...)`.
- Remove `selectedPointIndex`; use hoisted `ChartSelection` or `staticChartSelection(index)` for deterministic previews and screenshots.
- Shared values are `Double` only.
- Categories are explicit indexed labels. Empty categories do not invent X-axis labels.
- Add separate `valueFormatter` and `axisValueFormatter` parameters.
- Add grouped Compose-friendly styles: `LineVisualStyle`, `LinePointStyle`, `LineSelectionStyle`, and `LineAxisStyle`.
- Preserve source-index selection across compact and expanded rendering, with data replacement clearing invalid selection.
- Keep Morph and Timeline modes, update animation controls, scroll/zoom behavior, and multi-series shared-index interaction.

## Validation and behavior

- Validate empty/ragged series, category mismatch, non-finite values, color-count mismatch, alpha, stroke width, and axis label counts before renderer conversion.
- Preserve previous line visual defaults at the temporary renderer boundary: line/axis/marker sizes remain numerically aligned with the old renderer while the public API uses `Dp`.
- Preserve single-series behavior without an extra legend; multi-series data retains category labels and series readouts.
- The temporary flat `LineChartInternalStyle` adapter is internal-only and is a follow-up renderer cleanup target, not a public compatibility API.

## Scope

- Migrated line previews, demos, view models, sample use cases, GIF scenarios, screenshot call sites, smoke consumer, shared fixtures, and tests.
- Added release notes and migration guide under `release-notes/3.0.0`.
- Legacy `ChartDataSet` / `MultiChartDataSet` remain in core for Radar, Stacked Bar, and Stacked Area until their final consumers migrate.

## Local validation

Passed locally:

- `./gradlew :charts-line:jvmTest :charts:jvmTest`
- `./gradlew :charts-line:compileTestKotlinWasmJs`
- `./gradlew :charts-line:ktlintCheck :sample-shared:ktlintCheck`
- `./gradlew :app:compileKotlinJvm`
- `./gradlew :androidApp:compileDebugKotlin`
- `./gradlew :androidApp:compileDebugScreenshotTestKotlin`
- `./gradlew :androidApp:updateDebugScreenshotTest` completed; corrected line baselines are byte-identical to the previous references, so no screenshot files are included in this PR.

CI should run the complete test matrix, Android screenshot validation, platform suites, and API compatibility checks.