### PR TITLE
fix(ci): fetch PR labels live and stop listening for label events

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -4,14 +4,6 @@ name: API Compatibility
 on:
   workflow_call:
     inputs:
-      has-breaking-label:
-        description: Whether the pull request has the breaking-change label.
-        required: true
-        type: boolean
-      should-run:
-        description: Whether the pull request contains code or build changes.
-        required: true
-        type: boolean
       source-sha:
         description: Immutable merge revision being checked.
         required: true
@@ -19,23 +11,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
-  skipped:
-    name: Docs-only no-op
-    if: ${{ !inputs.should-run }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report docs-only no-op
-        run: echo 'No code changes require the API compatibility check.'
-
   api-compatibility:
     name: Compare Public API Against Release
-    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
-    env:
-      HAS_BREAKING_LABEL: ${{ inputs.has-breaking-label }}
     steps:
+      - name: Fetch current PR labels
+        id: labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          has_breaking_label="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" |
+            jq -s 'any(.[][]; .name == "breaking-change")')"
+          echo "has_breaking_label=${has_breaking_label}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v7
         with:
@@ -57,7 +52,7 @@ jobs:
           set +e
           set -o pipefail
 
-          ./gradlew apiCompatibilityCheck --no-daemon 2>&1 | tee api-compatibility.log
+          ./gradlew apiCompatibilityCheck --no-daemon --console=plain 2>&1 | tee api-compatibility.log
           exit_code=${PIPESTATUS[0]}
           set -e
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
@@ -67,6 +62,7 @@ jobs:
         shell: bash
         env:
           EXIT_CODE: ${{ steps.compatibility.outputs.exit_code }}
+          HAS_BREAKING_LABEL: ${{ steps.labels.outputs.has_breaking_label }}
         run: |
           set -euo pipefail
 
@@ -108,6 +104,7 @@ jobs:
         shell: bash
         env:
           EXIT_CODE: ${{ steps.compatibility.outputs.exit_code }}
+          HAS_BREAKING_LABEL: ${{ steps.labels.outputs.has_breaking_label }}
         run: |
           set -euo pipefail
           if [[ -z "${EXIT_CODE}" ]]; then

--- a/.github/workflows/pull-request-api.yml
+++ b/.github/workflows/pull-request-api.yml
@@ -4,99 +4,35 @@ name: Pull Request API Compatibility
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: >-
-    ${{
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened' ||
-        (
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          github.event.label.name == 'breaking-change'
-        )
-      ) &&
-      format('pr-api-{0}', github.event.pull_request.number) ||
-      format('pr-api-ignored-{0}', github.run_id)
-    }}
+  group: pr-api-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  prepare-api:
-    name: Prepare API Compatibility
-    if: >-
-      ${{
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened' ||
-        (
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          github.event.label.name == 'breaking-change'
-        )
-      }}
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.changes.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Detect code changes
-        id: changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          should_run="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
-          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
-
   api-compatibility:
     name: Internal API Compatibility
-    needs: prepare-api
     uses: ./.github/workflows/api-compatibility.yml
     with:
-      has-breaking-label: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
-      should-run: >-
-        ${{
-          needs.prepare-api.outputs.should_run == 'true' ||
-          (
-            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-            github.event.label.name == 'breaking-change'
-          )
-        }}
       source-sha: ${{ github.sha }}
 
   api-result:
-    name: >-
-      ${{
-          needs.prepare-api.result != 'skipped' &&
-          'PR API Compatibility' ||
-          'API compatibility not requested'
-      }}
-    if: ${{ always() && needs.prepare-api.result != 'skipped' }}
-    needs:
-      - prepare-api
-      - api-compatibility
+    name: PR API Compatibility
+    if: ${{ always() }}
+    needs: api-compatibility
     runs-on: ubuntu-latest
     steps:
       - name: Verify API compatibility
         env:
-          PREPARE_RESULT: ${{ needs.prepare-api.result }}
           API_RESULT: ${{ needs.api-compatibility.result }}
         run: |
-          for result in \
-            "$PREPARE_RESULT" \
-            "$API_RESULT"
-          do
-            if [ "$result" != "success" ]; then
-              echo "A required API check did not succeed: $result"
-              exit 1
-            fi
-          done
+          if [ "$API_RESULT" != "success" ]; then
+            echo "The API compatibility check did not succeed: $API_RESULT"
+            exit 1
+          fi

--- a/.github/workflows/pull-request-gif-validation.yml
+++ b/.github/workflows/pull-request-gif-validation.yml
@@ -4,54 +4,42 @@ name: Pull Request GIF Validation
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: >-
-    ${{
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened' ||
-        (
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'run-gif-validation'
-        ) ||
-        (
-          github.event.action == 'unlabeled' &&
-          github.event.label.name == 'run-gif-validation'
-        )
-      ) &&
-      format('pr-gif-{0}', github.event.pull_request.number) ||
-      format('pr-gif-ignored-{0}', github.run_id)
-    }}
+  group: pr-gif-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  check-label:
+    name: Check GIF Validation Label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.labels.outputs.should_run }}
+    steps:
+      - name: Fetch current PR labels
+        id: labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          should_run="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" |
+            jq -s 'any(.[][]; .name == "run-gif-validation")')"
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
+
   gif-validation:
     # Optional: keep this out of the required-status-check ruleset.
     name: PR GIF Baseline Validation
-    if: >-
-      ${{
-        (
-          (
-            github.event.action == 'opened' ||
-            github.event.action == 'synchronize' ||
-            github.event.action == 'reopened'
-          ) &&
-          contains(github.event.pull_request.labels.*.name, 'run-gif-validation')
-        ) ||
-        (
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'run-gif-validation' &&
-          contains(github.event.pull_request.labels.*.name, 'run-gif-validation')
-        )
-      }}
+    needs: check-label
+    if: ${{ needs.check-label.outputs.should_run == 'true' }}
     uses: ./.github/workflows/validate-gifs.yml
     with:
-      should-run: true
       source-sha: ${{ github.sha }}

--- a/.github/workflows/validate-gifs.yml
+++ b/.github/workflows/validate-gifs.yml
@@ -7,10 +7,6 @@ name: GIF Baseline Validation
 on:
   workflow_call:
     inputs:
-      should-run:
-        description: Whether the pull request has explicitly requested GIF validation.
-        required: true
-        type: boolean
       source-sha:
         description: Immutable revision being checked.
         required: true
@@ -22,7 +18,6 @@ permissions:
 jobs:
   validate:
     name: Validate GIF baselines
-    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/docs/workflows/api-compatibility.md
+++ b/docs/workflows/api-compatibility.md
@@ -10,8 +10,7 @@ Workflows:
 ```mermaid
 flowchart TD
   A["PR opened, synchronized, or reopened"] --> B["Pull Request API Compatibility"]
-  L["breaking-change label added or removed"] --> B
-  B --> C["Run API Compatibility when required"]
+  B --> C["Run API Compatibility"]
   C --> D{"Breaking API change detected?"}
   D -- No --> E["Pass: API remains compatible"]
   D -- Yes --> F{"PR has breaking-change label?"}
@@ -22,17 +21,15 @@ flowchart TD
 ```
 
 The `Pull Request API Compatibility` workflow runs for the `opened`,
-`synchronize`, and `reopened` pull-request actions. It also runs when the
-`breaking-change` label is added or removed. Events for other labels do not
-allocate an API runner. The reusable `API Compatibility` workflow runs the
-Gradle check when the pull request contains code/build changes or when a
-`breaking-change` label event forces the check.
+`synchronize`, and `reopened` pull-request actions. It runs the Gradle
+compatibility check for every such event, including documentation-only changes.
+The `breaking-change` label is evaluated as policy input: it allows an
+intentional API break but does not trigger a separate workflow run.
 
-The reusable workflow exposes both the real compatibility job and a
-`Docs-only no-op` job. GitHub displays the inactive job as
-skipped even when the real compatibility job is running. That row is only the
-unselected alternative; it does not mean that this pull request lacks code
-changes.
+The compatibility job fetches current PR labels from the GitHub API on each
+attempt rather than using the original event's label snapshot. After adding
+`breaking-change` for an intentional incompatibility, use **Re-run failed jobs**
+or **Re-run all jobs** to evaluate it without pushing another commit.
 
 If a breaking change is acknowledged with the `breaking-change` label and
 merged, the post-merge baseline update flow below runs automatically.

--- a/docs/workflows/pull-request-orchestration.md
+++ b/docs/workflows/pull-request-orchestration.md
@@ -2,20 +2,24 @@
 
 Pull-request CI is split into three independently triggered workflows: core
 checks, API compatibility, and optional GIF validation. Core checks and API
-compatibility use separate concurrency groups so events for one label cannot
-cancel unrelated work. Each workflow uses the immutable `github.sha` for the
-pull-request event that started it.
+compatibility use separate concurrency groups. Each workflow uses the immutable
+`github.sha` for the pull-request event that started it.
 
 ## Labels
 
-- `breaking-change` marks an intentional public API incompatibility. Adding or
-  removing this label runs API compatibility, even when the pull request only
-  changes documentation or release notes. The label does not start or cancel
-  core checks.
+- `breaking-change` marks an intentional public API incompatibility. The API
+  compatibility job fetches current labels from the GitHub API on every attempt,
+  including failed-job reruns. Adding or removing it does not trigger a separate
+  API run.
 - `run-gif-validation` opts a pull request into GIF baseline validation. The
-  validation runs for normal pull-request events while this label is present,
-  starts when the label is added, and is cancelled when the label is removed.
-  It is informational and is not a required status check.
+  validation runs for normal pull-request events while this label is present.
+  Adding or removing the label does not trigger a separate validation run. It
+  is informational and is not a required status check.
+
+After changing `breaking-change`, rerun the failed API jobs or all jobs. After
+changing `run-gif-validation`, use **Re-run all jobs** in the GIF workflow so its
+label-check job fetches the current labels before deciding whether to validate.
+Failed-job-only reruns reuse the output of a previously successful label check.
 
 ## Flow
 
@@ -36,18 +40,16 @@ pull-request actions. Its `PR Core Checks` gate fails if preparation or any
 dependent core check fails or is cancelled. Documentation-only changes still
 use the reusable workflows' successful no-op path.
 
-The API workflow listens for the same three pull-request actions plus
-`labeled` and `unlabeled`. For label actions, only an event for the
-`breaking-change` label is relevant. Events for other labels skip `Prepare API
-Compatibility` before a runner is allocated. The API result gate derives its
-required name and execution eligibility from that preparation result rather
-than repeating the event expression.
+The API workflow listens for the same three pull-request actions as the core
+workflow and always runs the compatibility check. Its `PR API Compatibility`
+gate reports the reusable workflow result as the required status check.
 
-The GIF workflow is optional. It runs on the three normal pull-request actions
-only when the `run-gif-validation` label is present, or when that label is
-added. Its `pr-gif-<PR number>` concurrency group cancels an active validation
-when the `run-gif-validation` label is removed; the removal event itself does
-not start a new validation.
+The GIF workflow is optional. Its label-check job runs on the three normal
+pull-request actions and fetches current labels from the GitHub API; the
+validation job runs only when `run-gif-validation` is present. Its
+`pr-gif-<PR number>` concurrency group cancels an active validation when a new
+commit supersedes it. Adding or removing the label alone does not start or
+cancel validation.
 
 ## Workflow responsibilities
 
@@ -58,7 +60,7 @@ not start a new validation.
 | `Compile` | Runs `./gradlew ciCompile`. |
 | `Lint` | Runs Kotlin and build-logic lint when the PR contains code/build changes. |
 | `Test` | Runs `ciTestJvm`, `ciTestAndroid`, `ciTestWeb`, and `ciTestIos` when needed; uploads Gradle's native HTML and XML reports. |
-| `Prepare API Compatibility` | Routes normal pull-request actions and changes to the `breaking-change` label, detects code changes, and prevents events for other labels from allocating a runner. |
+| `PR API Compatibility` | Runs the API compatibility check for every normal pull-request event and reports the required result. |
 | `API compatibility` | Runs `./gradlew apiCompatibilityCheck`; a detected public API incompatibility requires the `breaking-change` label. |
 | `GIF validation` | Runs the opt-in GIF baseline workflow while the `run-gif-validation` label is present. |
 
@@ -69,20 +71,9 @@ compile belongs only to `ciCompile`, not to a test task.
 
 The core reusable workflows receive `source-sha` from `Prepare PR`. API and
 GIF validation receive the triggering event's `github.sha`, so each check uses
-the immutable merge result for that event. Core and API workflows retain their
-code-change optimization, while changes to the `breaking-change` label force
-API compatibility even when no code change is detected.
-
-The repeated API event condition is intentional in only these places:
-
-- `concurrency.group`: relevant API events share `pr-api-<PR number>` and
-  events for other labels receive an isolated group.
-- `prepare-api.if`: events for other labels do not allocate an API runner.
-- the `api-compatibility` reusable-workflow `should-run` input: adding or
-  removing `breaking-change` forces the compatibility check.
-
-Downstream API jobs use `needs.prepare-api.result` instead of repeating the
-event condition.
+the immutable merge result for that event. Core checks retain their
+code-change optimization; API compatibility always runs for normal
+pull-request events and uses the `breaking-change` label only as policy input.
 
 ## Merge protection
 
@@ -93,10 +84,9 @@ PR Core Checks
 PR API Compatibility
 ```
 
-Do not require `Prepare PR`, `Prepare API Compatibility`, individual
-implementation jobs, or `PR GIF Baseline Validation`; GIF validation is
-optional. Rulesets match status-check contexts literally, so keep the required
-names exactly as shown above.
+Do not require `Prepare PR`, individual implementation jobs, or `PR GIF Baseline
+Validation`; GIF validation is optional. Rulesets match status-check contexts
+literally, so keep the required names exactly as shown above.
 
 ## Fork PR security boundary
 
@@ -110,20 +100,16 @@ access and must not execute untrusted PR code.
 ## Docs-only changes
 
 `scripts/ci-has-code-changes.sh` treats documentation and release-note-only
-changes as non-code changes. For the normal `opened`, `synchronize`, and
-`reopened` actions, `Prepare PR` and `Prepare API Compatibility` run, while the
-core and API reusable workflows take their successful no-op paths. A
-`breaking-change` label addition or removal is the exception: it forces API
-compatibility even for a docs-only pull request. Events for other labels skip
-API preparation and do not allocate an API runner.
+changes as non-code changes for the core workflow. The API compatibility
+workflow still runs for those changes because it always checks the current
+public API against the baseline.
 
 ## Reusable workflow status display
 
-The reusable core and API workflows define two mutually exclusive paths for
-some checks:
+The reusable core workflows define two mutually exclusive paths for some
+checks:
 
-- the real validation job, such as `Assemble` or `Compare Public API Against
-  Release`;
+- the real validation job, such as `Assemble`;
 - an explicit docs-only no-op job named `Docs-only no-op`.
 
 GitHub displays both job definitions in the run, even though only one path is
@@ -133,8 +119,9 @@ passing. That skipped row is the inactive alternative; it does not mean that
 the pull request had no code changes and is not an additional required check.
 
 For a docs-only pull request, the no-op job succeeds and the real validation
-job is skipped. The aggregate `PR Core Checks` and `PR API Compatibility` jobs
-then verify the result of the selected path.
+job is skipped for the core workflow, while API compatibility still runs. The
+aggregate `PR Core Checks` job verifies the core no-op path, and
+`PR API Compatibility` verifies the API result.
 
 The optional `PR GIF Baseline Validation` job is different: when it is skipped,
 the `run-gif-validation` label was not present and GIF validation was not


### PR DESCRIPTION
## Summary

The label-triggered API and GIF workflows produced unreliable reruns because GitHub replays the original event payload on rerun, so adding or removing a label after a failure did not update the policy decision.

This change drops the `labeled`/`unlabeled` triggers and their per-label concurrency branches, runs API compatibility on every normal pull-request event, and refreshes label state on every attempt via the GitHub API.

## Changes

- Drop `labeled`/`unlabeled` from the pull-request event types and remove the per-label concurrency branches.
- Always run API compatibility on `opened`, `synchronize`, and `reopened`.
- Fetch current PR labels inside the API compatibility job and a new GIF label-check job via `gh api --paginate`, then gate validation on the fresh result.
- Compare labels exactly against the GitHub JSON response (`jq -s` over an array of label names) instead of a comma-joined substring match.
- Grant `pull-requests: read` to the API caller so the reusable workflow can read labels.
- Call `validate-gifs.yml` at job level via a `check-label` job, not as a step.
- Document rerun behavior for both workflows in `docs/workflows/api-compatibility.md` and `docs/workflows/pull-request-orchestration.md`.

## Verification

- `actionlint` clean on all four modified workflows.
- 71 targeted structural and label-lookup checks (Ruby harness): trigger types, no reusable-workflow-as-step, caller grants required permissions, label pagination and exact-name matching, API policy outcomes, label-check failure modes (API failure, malformed JSON).
- `gh api --paginate … | jq -s` ran successfully against a real GitHub repo (`actions/runner`).

Full GitHub-hosted workflow runs were not executed.

## Rerun behavior

- After adding `breaking-change`, use **Re-run failed jobs** or **Re-run all jobs** for the API workflow.
- After adding or removing `run-gif-validation`, use **Re-run all jobs** in the GIF workflow so its `check-label` job re-fetches labels.