### PR TITLE
ci(api): update API compatibility baseline

### DIFF
--- a/.github/api-compatibility-baseline.txt
+++ b/.github/api-compatibility-baseline.txt
@@ -1,4 +1,4 @@
 # Baseline commit used by API compatibility workflow.
 # Updated via set-api-baseline workflow.
-# source: pull_request_target:merge_commit_sha:550
-3be9e788351953b8335baa917f5d3d3aef097492
+# source: pull_request_target:merge_commit_sha:552
+9a2fa1c09ea95967ac839be9ec13a64e8a6052d5


### PR DESCRIPTION
Updates `.github/api-compatibility-baseline.txt` to a new baseline value.

- source: `pull_request_target:merge_commit_sha:552`
- value: `9a2fa1c09ea95967ac839be9ec13a64e8a6052d5`