### PR TITLE
feat(pie): align PieSlice value with v3 Double contract

### DIFF
--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChart.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChart.kt
@@ -73,7 +73,7 @@ fun PieChart(
             )
         }
     val labels = remember(data) { data.map { it.label }.toImmutableList() }
-    val points = remember(data) { data.map { it.value.toDouble() }.toImmutableList() }
+    val points = remember(data) { data.map { it.value }.toImmutableList() }
 
     PieChartContent(
         modifier = modifier,

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChartPreviews.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/PieChartPreviews.kt
@@ -8,7 +8,7 @@ import io.github.dautovicharis.charts.style.PieChartDefaults
 import io.github.dautovicharis.charts.style.PieChartStyle
 
 private const val PIE_CHART_TITLE = "Pie Chart"
-private val PIE_VALUES = listOf(32f, 21f, 24f, 14f, 9f)
+private val PIE_VALUES = listOf(32.0, 21.0, 24.0, 14.0, 9.0)
 private val PIE_LABELS = listOf("North", "East", "South", "West", "Other")
 private val PIE_SLICES =
     PIE_LABELS.mapIndexed { index, label -> PieSlice(label = label, value = PIE_VALUES[index]) }
@@ -45,7 +45,7 @@ private fun PieChartPreview() {
 private fun PieChartErrorPreview() {
     ChartsPreviewTheme {
         PieChart(
-            data = listOf(PieSlice(label = "Slice 1", value = 42f)),
+            data = listOf(PieSlice(label = "Slice 1", value = 42.0)),
             style = PieChartDefaults.style(),
             title = PIE_CHART_TITLE,
         )

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
@@ -60,12 +60,13 @@ internal fun PieChart(
     val isPreview = LocalInspectionMode.current
     var show by rememberShowState(isPreviewMode = isPreview || !animateOnStart)
     val values = chartData.points
+    val interactionSlices = remember(values) { createPieSlices(values) }
     val animatables =
-        remember(values.size, isPreview, animateOnStart) {
-            List(values.size) { index ->
+        remember(interactionSlices, isPreview, animateOnStart) {
+            List(interactionSlices.size) { index ->
                 val initialValue =
                     if (isPreview || !animateOnStart) {
-                        values[index].toFloat()
+                        interactionSlices[index].normalizedValue.toFloat()
                     } else {
                         0f
                     }
@@ -73,13 +74,13 @@ internal fun PieChart(
             }
         }
     val hasInitialized = remember { mutableStateOf(false) }
-    LaunchedEffect(values, isPreview, animateOnStart) {
-        if (values.isEmpty()) return@LaunchedEffect
+    LaunchedEffect(interactionSlices, isPreview, animateOnStart) {
+        if (interactionSlices.isEmpty()) return@LaunchedEffect
         val shouldAnimate = !isPreview && (animateOnStart || hasInitialized.value)
         coroutineScope {
-            values.forEachIndexed { index, value ->
+            interactionSlices.forEachIndexed { index, slice ->
                 launch {
-                    val target = value.toFloat()
+                    val target = slice.normalizedValue.toFloat()
                     if (!shouldAnimate) {
                         animatables[index].snapTo(target)
                     } else {
@@ -94,7 +95,6 @@ internal fun PieChart(
         hasInitialized.value = true
     }
 
-    val interactionSlices = remember(values) { createPieSlices(values) }
     var selectedIndex by remember { mutableIntStateOf(NO_SELECTION) }
     LaunchedEffect(selectedSliceIndex) {
         selectedIndex = selectedSliceIndex

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChartHelpers.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChartHelpers.kt
@@ -104,10 +104,17 @@ internal fun createPieSlices(data: ChartData): List<SliceGeometry> = createPieSl
 internal fun createPieSlices(values: List<Double>): List<SliceGeometry> =
     mutableListOf<SliceGeometry>().apply {
         var lastEndDeg = 0.0
-        val maxValue = values.sum()
+        val maxValue = values.maxOrNull() ?: 0.0
+        val scaledTotal =
+            if (maxValue > 0.0) {
+                values.sumOf { it / maxValue }
+            } else {
+                0.0
+            }
         for (slice in values) {
             val startDeg = lastEndDeg
-            val normalized = if (maxValue == 0.0) 0.0 else slice / maxValue
+            val normalized =
+                if (scaledTotal == 0.0) 0.0 else (slice / maxValue) / scaledTotal
             val endDeg = lastEndDeg + (normalized * 360)
             lastEndDeg = endDeg
             add(

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/model/PieSlice.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/model/PieSlice.kt
@@ -11,13 +11,14 @@ import androidx.compose.ui.graphics.Color
  * impossible to supply a color count that does not match the slice count.
  *
  * @param label The slice label, shown in the legend and while the slice is selected.
- * @param value The slice value. The rendered arc is proportional to this value.
+ * @param value The slice value. The rendered arc is proportional to this value. Values use
+ * `Double` to preserve precision until the renderer normalizes the pie geometry.
  * @param color The slice color. When `null`, a shade is generated from the style's
  * base color.
  */
 @Immutable
 data class PieSlice(
     val label: String,
-    val value: Float,
+    val value: Double,
     val color: Color? = null,
 )

--- a/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
+++ b/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
@@ -35,12 +35,12 @@ import kotlin.test.assertNull
 class PieChartTest {
     private val pieSlices =
         listOf(
-            PieSlice(label = "A", value = 10f),
-            PieSlice(label = "B", value = 20f),
-            PieSlice(label = "C", value = 30f),
-            PieSlice(label = "D", value = 40f),
+            PieSlice(label = "A", value = 10.0),
+            PieSlice(label = "B", value = 20.0),
+            PieSlice(label = "C", value = 30.0),
+            PieSlice(label = "D", value = 40.0),
         )
-    private val points: List<Double> = pieSlices.map { it.value.toDouble() }
+    private val points: List<Double> = pieSlices.map { it.value }
     private val labels: List<String> = pieSlices.map { it.label }
 
     @OptIn(ExperimentalTestApi::class)
@@ -86,7 +86,7 @@ class PieChartTest {
     @Test
     fun pieChart_withInvalidData_displaysError() =
         runComposeUiTest {
-            val invalidSlices = listOf(PieSlice(label = "A", value = 1f))
+            val invalidSlices = listOf(PieSlice(label = "A", value = 1.0))
             val expectedError = RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_PIE)
 
             setContent {

--- a/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/PieChartHelpersTest.kt
+++ b/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/PieChartHelpersTest.kt
@@ -139,6 +139,14 @@ class PieChartHelpersTest {
     }
 
     @Test
+    fun createPieSlices_normalizesDoubleValuesBeforeGeometryConversion() {
+        val slices = createPieSlices(values = listOf(1e40, 1e40))
+
+        assertEquals(180f, slices[0].sweepAngle)
+        assertEquals(180f, slices[1].sweepAngle)
+    }
+
+    @Test
     fun calculatePercentages_returnsCorrectPercentages() {
         // Arrange
         val testData =

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
@@ -16,8 +16,8 @@ class DataValidationPieTest {
     fun validatePieData_validSlices_noValidationErrors() {
         val slices =
             listOf(
-                PieSlice(label = "A", value = 1f),
-                PieSlice(label = "B", value = 2f),
+                PieSlice(label = "A", value = 1.0),
+                PieSlice(label = "B", value = 2.0),
             )
 
         val validationErrors = validatePieData(slices)
@@ -27,7 +27,7 @@ class DataValidationPieTest {
 
     @Test
     fun validatePieData_tooFewSlices_validationErrorsPresent() {
-        val slices = listOf(PieSlice(label = "A", value = 10f))
+        val slices = listOf(PieSlice(label = "A", value = 10.0))
 
         val validationErrors = validatePieData(slices)
 
@@ -41,9 +41,9 @@ class DataValidationPieTest {
     fun validatePieData_nanValue_validationErrorsPresent() {
         val slices =
             listOf(
-                PieSlice(label = "A", value = 1f),
-                PieSlice(label = "B", value = Float.NaN),
-                PieSlice(label = "C", value = 3f),
+                PieSlice(label = "A", value = 1.0),
+                PieSlice(label = "B", value = Double.NaN),
+                PieSlice(label = "C", value = 3.0),
             )
 
         val validationErrors = validatePieData(slices)
@@ -57,9 +57,9 @@ class DataValidationPieTest {
     fun validatePieData_negativeValue_validationErrorsPresent() {
         val slices =
             listOf(
-                PieSlice(label = "A", value = 1f),
-                PieSlice(label = "B", value = -2f),
-                PieSlice(label = "C", value = 3f),
+                PieSlice(label = "A", value = 1.0),
+                PieSlice(label = "B", value = -2.0),
+                PieSlice(label = "C", value = 3.0),
             )
 
         val validationErrors = validatePieData(slices)

--- a/release-notes/3.0.0/changes/pie-v3-numeric-alignment.md
+++ b/release-notes/3.0.0/changes/pie-v3-numeric-alignment.md
@@ -1,0 +1,5 @@
+# PR Changeset
+
+- type: `feat`
+- module: `charts-pie`
+- release_note: `Change PieSlice.value from Float to Double for the v3 numeric contract and migrate Pie examples and consumers to explicit Double values.`

--- a/release-notes/3.0.0/migrations/pie-v3-numeric-alignment.md
+++ b/release-notes/3.0.0/migrations/pie-v3-numeric-alignment.md
@@ -1,0 +1,28 @@
+# Pie Slice Numeric Migration
+
+`PieSlice.value` is now `Double`. The public `PieChart` call shape and Pie styles remain unchanged.
+
+Before:
+
+```kotlin
+PieChart(
+    data = listOf(
+        PieSlice(label = "Completed", value = 80f),
+        PieSlice(label = "Remaining", value = 20f),
+    ),
+)
+```
+
+After:
+
+```kotlin
+PieChart(
+    data = listOf(
+        PieSlice(label = "Completed", value = 80.0),
+        PieSlice(label = "Remaining", value = 20.0),
+    ),
+)
+```
+
+There are no Float convenience overloads. Convert or parse values at the application boundary with
+`toDouble()` when the source data is still Float or another numeric representation.

--- a/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/ChartGalleryPreviews.kt
+++ b/sample/app/src/commonMain/kotlin/dev/hdcode/charts/app/ChartGalleryPreviews.kt
@@ -98,7 +98,7 @@ private fun PieChartPreview(values: List<Float>) {
     val data =
         remember(values) {
             values.mapIndexed { index, value ->
-                PieSlice(label = "Segment ${index + 1}", value = value)
+                PieSlice(label = "Segment ${index + 1}", value = value.toDouble())
             }
         }
     PieChart(

--- a/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultPieSampleUseCase.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/hdcode/charts/sampleshared/data/impl/DefaultPieSampleUseCase.kt
@@ -11,10 +11,10 @@ internal class DefaultPieSampleUseCase : PieSampleUseCase {
         private val REFRESH_RANGE = 5..45
     }
 
-    private val pieDefaultValues = listOf(32f, 21f, 24f, 14f, 9f)
+    private val pieDefaultValues = listOf(32.0, 21.0, 24.0, 14.0, 9.0)
     private val pieDefaultLabels =
         listOf("Heating", "Cooling", "Appliances", "Water Heating", "Lighting")
-    private val pieCustomValues = listOf(35f, 20f, 12f, 8f, 18f, 7f)
+    private val pieCustomValues = listOf(35.0, 20.0, 12.0, 8.0, 18.0, 7.0)
     private val pieCustomLabels =
         listOf("Housing", "Food", "Transport", "Healthcare", "Savings", "Leisure")
 
@@ -39,7 +39,7 @@ internal class DefaultPieSampleUseCase : PieSampleUseCase {
         numOfPoints: IntRange,
     ): PieSampleData {
         val points = numOfPoints.random()
-        val values = List(points) { range.random().toFloat() }
+        val values = List(points) { range.random().toDouble() }
         return buildPieSample(
             values = values,
             labels = defaultLabels(points),
@@ -48,7 +48,7 @@ internal class DefaultPieSampleUseCase : PieSampleUseCase {
     }
 
     override fun pieCustomSample(range: IntRange): PieSampleData {
-        val values = List(pieCustomLabels.size) { range.random().toFloat() }
+        val values = List(pieCustomLabels.size) { range.random().toDouble() }
         return buildPieSample(
             values = values,
             labels = pieCustomLabels,
@@ -57,7 +57,7 @@ internal class DefaultPieSampleUseCase : PieSampleUseCase {
     }
 
     private fun buildPieSample(
-        values: List<Float>,
+        values: List<Double>,
         labels: List<String>,
         title: String = DEFAULT_TITLE,
     ): PieSampleData {


### PR DESCRIPTION
## Summary

- Change `PieSlice.value` from `Float` to `Double` without adding compatibility overloads.
- Preserve Double precision through pie normalization and animation preparation.
- Migrate Pie previews, tests, samples, and release documentation.

## Scope

This PR is intentionally limited to the v3 numeric/API contract. It does not change validation, hit-testing, selection lifecycle, styles, interaction behavior, or existing comments.

## Validation

- `./gradlew :charts-pie:jvmTest :charts:jvmTest :charts-pie:ktlintCheck`
- `./gradlew :app:compileKotlinJvm :sample-shared:compileKotlinJvm`
- `./gradlew :charts-pie:compileTestKotlinWasmJs :charts:compileTestKotlinWasmJs`