### PR TITLE
chore(agent): add hdc skills and agent guides

### DIFF
--- a/.agents/skills/hdc-changeset/SKILL.md
+++ b/.agents/skills/hdc-changeset/SKILL.md
@@ -5,8 +5,15 @@ description: Create or update a release changeset for the current repository. Us
 
 # Create release changesets
 
-Scope: the current repository. Commit and push actions require an explicit user
-request.
+Scope: the current repository.
+
+## Guardrails
+
+Follow the commit, push, and pull-request policy — including the
+git-actions questionnaire — in the Guardrails section of
+[hdc-pr](../hdc-pr/SKILL.md). Creating the changeset file in the working
+tree does NOT grant permission to commit, push, or open a PR; wait for an
+explicit ship request.
 
 ## User-impact gate
 

--- a/.agents/skills/hdc-changeset/SKILL.md
+++ b/.agents/skills/hdc-changeset/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: hdc-changeset
+description: Create or update a release changeset for the current repository. Use when the user asks to create or update release notes for a user-facing change.
+---
+
+# Create release changesets
+
+Scope: the current repository. Commit and push actions require an explicit user
+request.
+
+## User-impact gate
+
+The changeset gate covers observable features, fixes, behavior changes, API
+changes, and public documentation changes.
+
+CI configuration, dependency updates with no behavior changes, internal
+refactors, build cleanup, formatting, linting, repository maintenance, and
+release-process documentation that does not affect users use the no-changeset
+result.
+
+For those changes, output exactly:
+
+```text
+No changeset needed.
+```
+
+## Workflow
+
+1. Resolve the current pull request number, or use the explicit number provided
+   by the user.
+2. Read `.version`, require `<major>.<minor>.<patch>-SNAPSHOT`, and remove the
+   suffix to obtain `release_version`.
+3. Ensure these directories exist:
+
+   ```text
+   release-notes/<release_version>/changes/
+   release-notes/<release_version>/migrations/
+   ```
+
+4. Create the changeset at:
+
+   ```text
+   release-notes/<release_version>/changes/<pr-number>-<short-kebab>.md
+   ```
+
+   Use [assets/pr-changeset.md](assets/pr-changeset.md) as the template.
+5. Populate and validate the type, published module, pull request URL,
+   release-note word count, and absence of template placeholders.
+6. Report the release version and created or updated path.

--- a/.agents/skills/hdc-changeset/SKILL.md
+++ b/.agents/skills/hdc-changeset/SKILL.md
@@ -5,15 +5,10 @@ description: Create or update a release changeset for the current repository. Us
 
 # Create release changesets
 
-Scope: the current repository.
-
 ## Guardrails
 
-Follow the commit, push, and pull-request policy — including the
-git-actions questionnaire — in the Guardrails section of
-[hdc-pr](../hdc-pr/SKILL.md). Creating the changeset file in the working
-tree does NOT grant permission to commit, push, or open a PR; wait for an
-explicit ship request.
+Follow [AGENTS.md](../../AGENTS.md) Guardrails. Working-tree edits do not
+grant permission to commit, push, or open a PR.
 
 ## User-impact gate
 

--- a/.agents/skills/hdc-changeset/agents/openai.yaml
+++ b/.agents/skills/hdc-changeset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HDCharts Changeset"
+  short_description: "Create HDCharts release changesets"
+  default_prompt: "Use $hdc-changeset to create or update the release changeset for my current change."

--- a/.agents/skills/hdc-changeset/assets/pr-changeset.md
+++ b/.agents/skills/hdc-changeset/assets/pr-changeset.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `<feature|fix|refactor|docs|chore>`
+- module: `<published-module>`
+- pr: `https://github.com/HDCharts/charts/pull/<number>`
+- release_note: `<plain-language sentence, maximum 20 words>`

--- a/.agents/skills/hdc-pr/SKILL.md
+++ b/.agents/skills/hdc-pr/SKILL.md
@@ -14,6 +14,27 @@ description: Create or update a pull request for this repository when the user e
 - Examples: `feat/pie-v3-numeric-hardening` and
   `feat(pie): align PieSlice value with v3 Double contract`.
 
+## Validation questionnaire
+
+Before committing, use the `question` tool to confirm which validation to run
+based on the scope of the changes:
+
+- Change confined to one chart module → scoped tests:
+  `./gradlew :charts-<module>:jvmTest`
+- Cross-module or `charts-core` change → full JVM tests:
+  `./gradlew chartsTestJvm`
+- Compose UI / visual change → screenshot baselines:
+  `./gradlew :androidApp:validateDebugScreenshotTest` (update via
+  `./gradlew updateScreenshots`)
+- Public API change → `./gradlew apiCompatibilityCheck`
+- Any change → `./gradlew ktlintCheck`
+
+Run the selected tasks and list the executed commands in the PR body
+Validation section.
+
+Do not run `./gradlew validateDocsGifBaselines` or instrumented Android tests
+locally: they are machine-dependent, slow, and run on CI when required.
+
 ## Workflow
 
 1. Determine the changeset status with the user-impact gate in
@@ -21,7 +42,9 @@ description: Create or update a pull request for this repository when the user e
 2. When the gate requires a changeset, ask the user for confirmation before
    creating it.
 3. After confirmation, invoke `hdc-changeset` to create the changeset.
-4. Commit and push the intended changes after the user asks to ship them.
-5. Find or create the pull request for the current repository, targeting `main`,
+4. Confirm the validation scope with the Validation questionnaire and run the
+   selected checks.
+5. Commit and push the intended changes after the user asks to ship them.
+6. Find or create the pull request for the current repository, targeting `main`,
    using `.github/PULL_REQUEST_TEMPLATE.md` for the body.
-6. Report the pull request URL and changeset status.
+7. Report the pull request URL and changeset status.

--- a/.agents/skills/hdc-pr/SKILL.md
+++ b/.agents/skills/hdc-pr/SKILL.md
@@ -1,7 +1,35 @@
 ---
 name: hdc-pr
-description: Create or update a pull request for this repository when the user explicitly asks to create, open, publish, or ship a PR.
+description: Create or update a pull request for this repository only after the user explicitly asks to create, open, publish, or ship a PR. Do NOT commit, push, or open a PR on your own.
 ---
+
+## Guardrails
+
+- Never commit, push, force-push, amend, create branches, or open a pull
+  request on your own. Each action requires an explicit user request.
+- Loading or invoking this skill does **not** grant permission. The skill
+  describes the workflow to follow **once** the user has asked to ship.
+- Before every destructive or external git action, use the `question` tool to
+  show the proposed command (and the diff summary for commits) and wait for
+  an explicit "yes". Never assume consent.
+- Preserve unrelated working-tree changes; isolate only the intended work.
+- Reuse an existing pull request and avoid duplicates.
+
+### Git-actions questionnaire
+
+Use the `question` tool with the proposed command summary and wait for an
+explicit yes before each of these actions:
+
+- **create branch** — `git checkout -b <branch> from <base>`
+- **commit** — `git commit` (show the staged diff summary and the proposed
+  commit subject)
+- **push** — `git push` (show the branch name and remote)
+- **force-push / amend** — `git push --force*`, `git push -f`, or
+  `git commit --amend` (always requires explicit yes; never default)
+- **open PR** — `gh pr create` (show the proposed title and body)
+
+When several actions are queued, batch them into a single `question` prompt
+so the user can approve the whole sequence at once.
 
 ## Branch and commit naming
 
@@ -38,13 +66,11 @@ locally: they are machine-dependent, slow, and run on CI when required.
 ## Workflow
 
 1. Determine the changeset status with the user-impact gate in
-   [hdc-changeset](../hdc-changeset/SKILL.md).
-2. When the gate requires a changeset, ask the user for confirmation before
-   creating it.
-3. After confirmation, invoke `hdc-changeset` to create the changeset.
-4. Confirm the validation scope with the Validation questionnaire and run the
-   selected checks.
-5. Commit and push the intended changes after the user asks to ship them.
-6. Find or create the pull request for the current repository, targeting `main`,
-   using `.github/PULL_REQUEST_TEMPLATE.md` for the body.
-7. Report the pull request URL and changeset status.
+   [hdc-changeset](../hdc-changeset/SKILL.md). If a changeset is required,
+   ask the user for confirmation before creating it.
+2. Run the Validation questionnaire and execute the selected checks.
+3. Show the proposed branch + commit + push + PR commands as one batched
+   `question` prompt (per the Git-actions questionnaire in Guardrails) and
+   wait for an explicit "yes" before executing any of them.
+4. After all actions succeed, report the pull request URL and changeset
+   status.

--- a/.agents/skills/hdc-pr/SKILL.md
+++ b/.agents/skills/hdc-pr/SKILL.md
@@ -1,35 +1,11 @@
 ---
 name: hdc-pr
-description: Create or update a pull request for this repository only after the user explicitly asks to create, open, publish, or ship a PR. Do NOT commit, push, or open a PR on your own.
+description: Create or update a pull request only after the user explicitly asks to create, open, publish, or ship a PR.
 ---
 
 ## Guardrails
 
-- Never commit, push, force-push, amend, create branches, or open a pull
-  request on your own. Each action requires an explicit user request.
-- Loading or invoking this skill does **not** grant permission. The skill
-  describes the workflow to follow **once** the user has asked to ship.
-- Before every destructive or external git action, use the `question` tool to
-  show the proposed command (and the diff summary for commits) and wait for
-  an explicit "yes". Never assume consent.
-- Preserve unrelated working-tree changes; isolate only the intended work.
-- Reuse an existing pull request and avoid duplicates.
-
-### Git-actions questionnaire
-
-Use the `question` tool with the proposed command summary and wait for an
-explicit yes before each of these actions:
-
-- **create branch** — `git checkout -b <branch> from <base>`
-- **commit** — `git commit` (show the staged diff summary and the proposed
-  commit subject)
-- **push** — `git push` (show the branch name and remote)
-- **force-push / amend** — `git push --force*`, `git push -f`, or
-  `git commit --amend` (always requires explicit yes; never default)
-- **open PR** — `gh pr create` (show the proposed title and body)
-
-When several actions are queued, batch them into a single `question` prompt
-so the user can approve the whole sequence at once.
+Follow [AGENTS.md](../../AGENTS.md) Guardrails.
 
 ## Branch and commit naming
 
@@ -70,7 +46,8 @@ locally: they are machine-dependent, slow, and run on CI when required.
    ask the user for confirmation before creating it.
 2. Run the Validation questionnaire and execute the selected checks.
 3. Show the proposed branch + commit + push + PR commands as one batched
-   `question` prompt (per the Git-actions questionnaire in Guardrails) and
-   wait for an explicit "yes" before executing any of them.
+   `question` prompt (per the git-actions questionnaire in
+   [AGENTS.md](../../AGENTS.md)) and wait for an explicit "yes" before
+   executing any of them.
 4. After all actions succeed, report the pull request URL and changeset
    status.

--- a/.agents/skills/hdc-pr/SKILL.md
+++ b/.agents/skills/hdc-pr/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: hdc-pr
+description: Create or update a pull request for this repository when the user explicitly asks to create, open, publish, or ship a PR.
+---
+
+## Branch and commit naming
+
+- Create feature branches from `main` with the format
+  `<type>/<short-kebab-summary>`.
+- Use branch types such as `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, and
+  `chore`.
+- Use commit subjects in the format `<type>(<scope>): <imperative summary>`.
+- Keep the type and scope lowercase and the summary concise.
+- Examples: `feat/pie-v3-numeric-hardening` and
+  `feat(pie): align PieSlice value with v3 Double contract`.
+
+## Workflow
+
+1. Determine the changeset status with the user-impact gate in
+   [hdc-changeset](../hdc-changeset/SKILL.md).
+2. When the gate requires a changeset, ask the user for confirmation before
+   creating it.
+3. After confirmation, invoke `hdc-changeset` to create the changeset.
+4. Commit and push the intended changes after the user asks to ship them.
+5. Find or create the pull request for the current repository, targeting `main`,
+   using `.github/PULL_REQUEST_TEMPLATE.md` for the body.
+6. Report the pull request URL and changeset status.

--- a/.agents/skills/hdc-pr/agents/openai.yaml
+++ b/.agents/skills/hdc-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ship HDCharts PR"
+  short_description: "Create coordinated HDCharts pull requests"
+  default_prompt: "Use $hdc-pr to safely create and coordinate the pull requests for my current HDCharts changes."

--- a/.agents/skills/hdc-rc/SKILL.md
+++ b/.agents/skills/hdc-rc/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: hdc-rc
+description: Run the configured HDCharts binary API compatibility check and generate concise per-PR migration fragments in charts. Use when the user asks to inspect breaking API changes, check snapshot or release compatibility, or update release migration notes.
+---
+
+# Check HDCharts release compatibility
+
+Generate incremental migration guidance from the library's API compatibility
+reports. Use the configured compatibility baseline for normal PR checks. Use
+the previous release tag for release audits. Migration fragments accumulate for
+the target release. The docs sync mirrors these fragments unchanged and the
+docs app assembles them at build time. Generate per-fragment migration guidance
+for the target release.
+
+## Guardrails
+
+- Commit, push, and pull request actions require an explicit user request.
+- Preserve migration fragments belonging to other pull requests.
+- Write when the intended fragment has a clean worktree state.
+- Inspect generated reports for every command result and distinguish reported
+  incompatibilities from infrastructure failures.
+
+
+## Workflow
+
+1. Read `charts/.version`, require
+   `<major>.<minor>.<patch>-SNAPSHOT`, remove the suffix to obtain
+   `release_version`, and use:
+
+   ```text
+   charts/release-notes/<release_version>/migrations/
+   ```
+
+2. Resolve the current `HDCharts/charts` pull request number. Search the target
+   migration directory for `<pr-number>-*.md`:
+   - exactly one matching fragment: reuse that path;
+   - multiple matching fragments: report the ambiguity before writing;
+   - no matching fragment: resolve a concise kebab-case summary and create:
+
+   ```text
+   <pr-number>-<short-kebab>.md
+   ```
+
+   Use an explicit user value when creating the first fragment. Complete the
+   compatibility inspection and omit writing when no stable fragment identity
+   exists.
+3. Resolve the baseline ref:
+   - release audits: use the previous release tag provided by the user or
+     inferred from the release history;
+   - standard checks: read the configured baseline ref from
+     `charts/.github/api-compatibility-baseline.txt`.
+4. Remove the generated
+   `charts/build/reports/api-compatibility/` directory before running the check.
+5. Run from `charts`:
+
+   ```text
+   ./gradlew apiCompatibilityCheck --no-daemon --continue
+   ```
+
+   For release audits, pass the previous release tag as the baseline:
+
+   ```text
+   ./gradlew apiCompatibilityCheck --no-daemon --continue -PapiCompatibilityBaselineRef=<previous-release-tag>
+   ```
+
+6. Capture the command's exit status and output. Classify API incompatibilities
+   separately from build, dependency, tool, and other infrastructure failures.
+   Report infrastructure failures and leave release notes unchanged.
+7. Read every Markdown report generated under
+   `build/reports/api-compatibility/`. Verify that every configured library
+   module expected to run produced a current report. Record modules whose
+   baseline artifact is unavailable and report those modules in the results.
+   Report failures for missing, stale, or incomplete reports and leave release
+   notes unchanged.
+8. For each module with a breaking change, determine:
+   - source call sites requiring edits;
+   - the user-visible API change;
+   - a minimal Kotlin before/after migration for required source edits.
+9. Update the current pull request's fragment using
+   [assets/migration-fragment.md](assets/migration-fragment.md):
+   - breaking modules: write one section per module with applicable migration
+     content;
+   - no breaking modules with an existing current fragment: remove the stale
+     fragment;
+   - no breaking modules with no current fragment: leave release notes
+     unchanged.
+10. Validate that no placeholders remain and that examples match the reports.
+11. Report the release version, baseline ref, command result, breaking modules,
+    and fragment path or no-write reason.

--- a/.agents/skills/hdc-rc/SKILL.md
+++ b/.agents/skills/hdc-rc/SKILL.md
@@ -14,13 +14,10 @@ for the target release.
 
 ## Guardrails
 
-- Follow the commit, push, and pull-request policy — including the
-  git-actions questionnaire — in the Guardrails section of
-  [hdc-pr](../hdc-pr/SKILL.md).
-- Preserve migration fragments belonging to other pull requests.
-- Write only when the intended fragment has a clean worktree state.
-- Inspect generated reports for every command result and distinguish reported
-  incompatibilities from infrastructure failures.
+Follow [AGENTS.md](../../AGENTS.md) Guardrails.
+
+Inspect generated reports for every command result and distinguish reported
+incompatibilities from infrastructure failures.
 
 
 ## Workflow

--- a/.agents/skills/hdc-rc/SKILL.md
+++ b/.agents/skills/hdc-rc/SKILL.md
@@ -14,9 +14,11 @@ for the target release.
 
 ## Guardrails
 
-- Commit, push, and pull request actions require an explicit user request.
+- Follow the commit, push, and pull-request policy — including the
+  git-actions questionnaire — in the Guardrails section of
+  [hdc-pr](../hdc-pr/SKILL.md).
 - Preserve migration fragments belonging to other pull requests.
-- Write when the intended fragment has a clean worktree state.
+- Write only when the intended fragment has a clean worktree state.
 - Inspect generated reports for every command result and distinguish reported
   incompatibilities from infrastructure failures.
 

--- a/.agents/skills/hdc-rc/agents/openai.yaml
+++ b/.agents/skills/hdc-rc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HDCharts Release Compatibility"
+  short_description: "Generate HDCharts migration fragments"
+  default_prompt: "Use $hdc-rc to check API compatibility and update the current release migration fragment."

--- a/.agents/skills/hdc-rc/assets/migration-fragment.md
+++ b/.agents/skills/hdc-rc/assets/migration-fragment.md
@@ -1,0 +1,26 @@
+## <module>
+
+### Reported API symbols
+
+- `<symbol from the API compatibility report>`
+
+### Do I need to update call sites?
+
+- No, if `<condition where no code changes are needed>`.
+- Yes, if `<condition where call-site updates are required>`.
+
+### What changed
+
+- `<short, user-facing description of the API change>`
+
+### Migration
+
+```kotlin
+// Before
+<old usage>
+
+// After
+<new usage>
+```
+
+- Recommended: `<optional best practice to avoid future breakage>`

--- a/.claude/skills/hdc-changeset
+++ b/.claude/skills/hdc-changeset
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-changeset

--- a/.claude/skills/hdc-pr
+++ b/.claude/skills/hdc-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-pr

--- a/.claude/skills/hdc-rc
+++ b/.claude/skills/hdc-rc
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-rc

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+-
+
+## Breaking Change
+
+<!-- Describe the breaking change and required migration, or remove this section. -->
+
+## Validation
+
+<!-- Mark each local gradlew command run for this change. -->
+
+- [ ] `./gradlew ktlintCheck`
+- [ ] `./gradlew :charts-<module>:jvmTest`
+- [ ] `./gradlew chartsTestJvm`
+- [ ] `./gradlew ciCompile`
+- [ ] `./gradlew chartsCheck`
+- [ ] `./gradlew apiCompatibilityCheck`
+- [ ] `./gradlew :androidApp:validateDebugScreenshotTest`
+- [ ] `./gradlew updateScreenshots`
+
+<!-- CI handles these — do not run locally; they are machine-dependent and slow:
+
+     ./gradlew validateDocsGifBaselines
+     ./gradlew chartsTestAndroid
+     ./gradlew chartsTestIos
+     ./gradlew chartsTestWasm -->

--- a/.kilo/skills/hdc-changeset
+++ b/.kilo/skills/hdc-changeset
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-changeset

--- a/.kilo/skills/hdc-pr
+++ b/.kilo/skills/hdc-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-pr

--- a/.kilo/skills/hdc-rc
+++ b/.kilo/skills/hdc-rc
@@ -1,0 +1,1 @@
+../../.agents/skills/hdc-rc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,13 @@
 | `hdc-pr` | The user explicitly asks to create, open, publish, or ship a pull request. | `.agents/skills/hdc-pr/SKILL.md` |
 | `hdc-changeset` | The user asks to create or update a release changeset for the current repository. | `.agents/skills/hdc-changeset/SKILL.md` |
 | `hdc-rc` | The user asks to inspect breaking API changes, check snapshot or release compatibility, or update release migration notes. | `.agents/skills/hdc-rc/SKILL.md` |
+
+## Commit, push, and pull-request policy
+
+- Never commit, push, force-push, amend, or open a pull request on your own.
+  These actions require an explicit request from the user.
+- Loading or invoking a skill (including `hdc-pr` and `hdc-changeset`) does
+  **not** grant permission to commit, push, or open a PR. Skills describe the
+  workflow to follow **once** the user has asked to ship the change.
+- Before any commit, push, or PR action, confirm with the user that the
+  current working-tree changes are the intended ones to ship.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Skills
+
+| Skill | Use when | Definition |
+| --- | --- | --- |
+| `hdc-pr` | The user explicitly asks to create, open, publish, or ship a pull request. | `.agents/skills/hdc-pr/SKILL.md` |
+| `hdc-changeset` | The user asks to create or update a release changeset for the current repository. | `.agents/skills/hdc-changeset/SKILL.md` |
+| `hdc-rc` | The user asks to inspect breaking API changes, check snapshot or release compatibility, or update release migration notes. | `.agents/skills/hdc-rc/SKILL.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@
 
 ## Commit, push, and pull-request policy
 
-- Never commit, push, force-push, amend, or open a pull request on your own.
-  These actions require an explicit request from the user.
-- Loading or invoking a skill (including `hdc-pr` and `hdc-changeset`) does
-  **not** grant permission to commit, push, or open a PR. Skills describe the
-  workflow to follow **once** the user has asked to ship the change.
-- Before any commit, push, or PR action, confirm with the user that the
-  current working-tree changes are the intended ones to ship.
+The single source of truth is the **Guardrails** section of
+[`.agents/skills/hdc-pr/SKILL.md`](.agents/skills/hdc-pr/SKILL.md)
+(including the git-actions questionnaire).
+
+Summary: never commit, push, force-push, amend, create branches, or open a
+pull request without an explicit user request. Loading a skill does not grant
+permission. Use the `question` tool before every destructive or external git
+action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,35 @@
 | `hdc-changeset` | The user asks to create or update a release changeset for the current repository. | `.agents/skills/hdc-changeset/SKILL.md` |
 | `hdc-rc` | The user asks to inspect breaking API changes, check snapshot or release compatibility, or update release migration notes. | `.agents/skills/hdc-rc/SKILL.md` |
 
-## Commit, push, and pull-request policy
+## Guardrails
 
-The single source of truth is the **Guardrails** section of
-[`.agents/skills/hdc-pr/SKILL.md`](.agents/skills/hdc-pr/SKILL.md)
-(including the git-actions questionnaire).
+These rules apply to every agent session in this repo and override
+conflicting instructions in skill files.
 
-Summary: never commit, push, force-push, amend, create branches, or open a
-pull request without an explicit user request. Loading a skill does not grant
-permission. Use the `question` tool before every destructive or external git
-action.
+- Never commit, push, create branches, or open a pull request on your own.
+  Each action requires an explicit user request.
+- Never suggest or use history-rewriting commands: `git push --force*`,
+  `git push -f`, `git commit --amend`, `git rebase`, or any other command
+  that rewrites published history. Always create a new commit instead.
+- Loading a skill does **not** grant permission to commit, push, or open a
+  PR; skills describe the workflow to follow **once** the user has asked to
+  ship the change.
+- Before every destructive or external git action, use the `question` tool to
+  show the proposed command (and the diff summary for commits) and wait for
+  an explicit "yes". Never assume consent.
+- Preserve unrelated working-tree changes; isolate only the intended work.
+- Reuse an existing pull request and avoid duplicates.
+
+### Git-actions questionnaire
+
+Before each of the following, use the `question` tool with the proposed
+command summary and wait for an explicit yes:
+
+- **create branch** — `git checkout -b <branch> from <base>`
+- **commit** — `git commit` (show the staged diff summary and the proposed
+  commit subject)
+- **push** — `git push` (show the branch name and remote)
+- **open PR** — `gh pr create` (show the proposed title and body)
+
+When several actions are queued, batch them into a single `question` prompt
+so the user can approve the whole sequence at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for repository instructions and available skills.


### PR DESCRIPTION
## Summary
- Add agent skill definitions for `hdc-changeset`, `hdc-pr`, and `hdc-rc` under `.agents/skills/` with symlinked entries for `.claude/` and `.kilo/`
- Add `AGENTS.md` and `CLAUDE.md` guides describing available skills

## Changeset
No changeset needed. Repository/agent tooling only; no user-facing behavior, API, or public documentation changes.